### PR TITLE
Implemented RequireBundleCheck and tests for it.

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Checks if the MANIFEST.MF file contains any "Require-Bundle" entries.
@@ -26,8 +26,8 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
  *
  */
 public class RequireBundleCheck extends AbstractStaticCheck {
-    private Log logger = LogFactory.getLog(RequireBundleCheck.class);
-    
+    private final Logger logger = LoggerFactory.getLogger(RequireBundleCheck.class);
+
     public static final String REQUIRE_BUNDLE_USED_MSG = "The MANIFEST.MF file must not contain any Require-Bundle entries. "
             + "Instead, Import-Package must be used.";
     private static final String MANIFEST_EXTENSTION = "MF";
@@ -44,15 +44,16 @@ public class RequireBundleCheck extends AbstractStaticCheck {
             // in the MANIFEST.MF
             Manifest manifest = new Manifest(new FileInputStream(file));
             Attributes attributes = manifest.getMainAttributes();
-            String requireBundleHeader = "Require-Bundle";
-            String requreBundleHeader = attributes.getValue(requireBundleHeader);
-            if(requreBundleHeader != null){
-                log(findLineNumber(lines, requreBundleHeader, 0), REQUIRE_BUNDLE_USED_MSG);
+
+            String requireBundleHeaderName = "Require-Bundle";
+            String requireBundleHeaderValue = attributes.getValue(requireBundleHeaderName);
+            if (requireBundleHeaderValue != null) {
+                log(findLineNumber(lines, requireBundleHeaderValue, 0), REQUIRE_BUNDLE_USED_MSG);
             }
         } catch (FileNotFoundException e) {
-            logger.debug("An exception was thrown while trying to open the file " + file.getPath(), e);
+            logger.debug("An exception was thrown while trying to open the file {}", file.getPath(), e);
         } catch (IOException e) {
-            logger.debug("An exception was thrown while trying to read the file " + file.getPath(), e);
+            logger.debug("An exception was thrown while trying to read the file {}", file.getPath(), e);
         }
     }
 }

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+
+/**
+ * Checks if the MANIFEST.MF file contains any "Require-Bundle" entries.
+ *
+ * @author Petar Valchev
+ *
+ */
+public class RequireBundleCheck extends AbstractStaticCheck {
+    private Log logger = LogFactory.getLog(RequireBundleCheck.class);
+    
+    public static final String REQUIRE_BUNDLE_USED_MSG = "The MANIFEST.MF file must not contain any Require-Bundle entries. "
+            + "Instead, Import-Package must be used.";
+    private static final String MANIFEST_EXTENSTION = "MF";
+
+    public RequireBundleCheck() {
+        setFileExtensions(MANIFEST_EXTENSTION);
+    }
+
+    @Override
+    protected void processFiltered(File file, List<String> lines) {
+        try {
+            // We use Manifest class here instead of ManifestParser,
+            // because it is easier to get the content of the headers
+            // in the MANIFEST.MF
+            Manifest manifest = new Manifest(new FileInputStream(file));
+            Attributes attributes = manifest.getMainAttributes();
+            String requireBundleHeader = "Require-Bundle";
+            String requreBundleHeader = attributes.getValue(requireBundleHeader);
+            if(requreBundleHeader != null){
+                log(findLineNumber(lines, requreBundleHeader, 0), REQUIRE_BUNDLE_USED_MSG);
+            }
+        } catch (FileNotFoundException e) {
+            logger.debug("An exception was thrown while trying to open the file " + file.getPath(), e);
+        } catch (IOException e) {
+            logger.debug("An exception was thrown while trying to read the file " + file.getPath(), e);
+        }
+    }
+}

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -50,7 +50,7 @@
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.RequireBundleCheck">
-      <property name="severity" value="warning" />
+      <property name="severity" value="error" />
    </module>
 
   <module name="TreeWalker">

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -48,6 +48,10 @@
   <module name="org.openhab.tools.analysis.checkstyle.OverridingParentPomConfigurationCheck">
     <property name="severity" value="warning" />
   </module>
+  
+  <module name="org.openhab.tools.analysis.checkstyle.RequireBundleCheck">
+      <property name="severity" value="warning" />
+   </module>
 
   <module name="TreeWalker">
     <!-- See http://checkstyle.sourceforge.net/config_coding.html#IllegalThrows -->

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2014-2016 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import java.io.File;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.RequireBundleCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link RequireBundleCheck}
+ *
+ * @author Petar Valchev
+ *
+ */
+public class RequireBundleCheckTest extends AbstractStaticCheckTest {
+    private static DefaultConfiguration config;
+
+    @BeforeClass
+    public static void setUpClass() {
+        config = createCheckConfig(RequireBundleCheck.class);
+    }
+
+    @Test
+    public void testExportedInternalPackage() throws Exception {
+        verifyManifest("require_bundle_manifest_directory", "REQUIRE_BUNDLE_MANIFEST.MF", 9,
+                RequireBundleCheck.REQUIRE_BUNDLE_USED_MSG);
+    }
+
+    @Test
+    public void testValidManifest() throws Exception {
+        verifyManifest("valid_manifest_directory", "VALID_MANIFEST.MF", 0, null);
+    }
+
+    @Override
+    protected DefaultConfiguration createCheckerConfig(Configuration config) {
+        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
+        defaultConfiguration.addChild(config);
+        return defaultConfiguration;
+    }
+
+    private void verifyManifest(String testDirectoryName, String testFileName, int expectedLine, String expectedMessage)
+            throws Exception {
+        String requireBundleCheckTestDirectory = "requireBundleCheckTest/";
+        String manifestRelativePath = requireBundleCheckTestDirectory + File.separator + testDirectoryName + File.separator + testFileName;
+        String manifestAbsolutePath = getPath(manifestRelativePath);
+        
+        String[] expectedMessages = null;
+        if(expectedMessage != null){
+            expectedMessages = generateExpectedMessages(expectedLine, RequireBundleCheck.REQUIRE_BUNDLE_USED_MSG);
+        } else {
+            expectedMessages = CommonUtils.EMPTY_STRING_ARRAY;
+        }
+        
+        verify(config, manifestAbsolutePath, expectedMessages);
+    }
+}

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2014-2017 by the respective copyright holders.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,16 +53,17 @@ public class RequireBundleCheckTest extends AbstractStaticCheckTest {
     private void verifyManifest(String testDirectoryName, String testFileName, int expectedLine, String expectedMessage)
             throws Exception {
         String requireBundleCheckTestDirectory = "requireBundleCheckTest/";
-        String manifestRelativePath = requireBundleCheckTestDirectory + File.separator + testDirectoryName + File.separator + testFileName;
+        String manifestRelativePath = requireBundleCheckTestDirectory + File.separator + testDirectoryName
+                + File.separator + testFileName;
         String manifestAbsolutePath = getPath(manifestRelativePath);
-        
+
         String[] expectedMessages = null;
-        if(expectedMessage != null){
+        if (expectedMessage != null) {
             expectedMessages = generateExpectedMessages(expectedLine, RequireBundleCheck.REQUIRE_BUNDLE_USED_MSG);
         } else {
             expectedMessages = CommonUtils.EMPTY_STRING_ARRAY;
         }
-        
+
         verify(config, manifestAbsolutePath, expectedMessages);
     }
 }

--- a/src/test/resources/checks/checkstyle/requireBundleCheckTest/require_bundle_manifest_directory/REQUIRE_BUNDLE_MANIFEST.MF
+++ b/src/test/resources/checks/checkstyle/requireBundleCheckTest/require_bundle_manifest_directory/REQUIRE_BUNDLE_MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Require-Bundle: javax.xml
+Import-Package: com.google.common.collect
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.other

--- a/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_manifest_directory/VALID_MANIFEST.MF
+++ b/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_manifest_directory/VALID_MANIFEST.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.other


### PR DESCRIPTION
This check verifies, that the `MANIFEST.MF` file does not contain any `Require-Bundle` headers. The best practice is to be used `Import-Package` header.