### PR TITLE
Remove warnings about missing xRefs in the build.

### DIFF
--- a/src/main/resources/configuration/checkstyle.properties
+++ b/src/main/resources/configuration/checkstyle.properties
@@ -3,3 +3,4 @@ checkstyle.console=true
 checkstyle.includes=src/main/java/**,OSGI-INF/**,META-INF/MANIFEST.MF,ESH-INF/**,.classpath,build.properties,pom.xml
 checkstyle.includeResources=false
 checkstyle.includeTestResources=false
+linkXRef=false

--- a/src/main/resources/configuration/pmd.properties
+++ b/src/main/resources/configuration/pmd.properties
@@ -1,1 +1,2 @@
 pmd.custom.targetDirectory=target/code-analysis
+linkXRef=false


### PR DESCRIPTION
PMD and checkstyle property linkXRef changed to false.

Fixes #18

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>