### PR TITLE
Replaced log4j logger with slf4j logger.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,8 @@
   <description>Tool that aggregates reports of PMD, Checkstyle and FindBugs</description>
 
   <properties>
-    <log4j.version>1.2.17</log4j.version>
+    <slf4j.api.version>1.7.24</slf4j.api.version>
+    <slf4j.simple.version>1.7.24</slf4j.simple.version>
     <junit.version>4.11</junit.version>
     <maven.resources.version>2.4</maven.resources.version>
     <pmd.version>5.5.1</pmd.version>
@@ -37,10 +38,16 @@
 
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.api.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.simple.version}</version>
+    </dependency>
+    
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,9 +1,0 @@
-# Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=INFO, A1
-
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
Replaced `log4j` logger with `slf4j` logger in the `pom.xml`, so that we could do parameterized logging.

I have also changed the logger in the `ReportUtility `class to `slf4j `and made the logging parameterized.