### PR TITLE
Add a check for bundle vendors 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 target
+.idea

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/BundleVendorCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/BundleVendorCheck.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Checks if a manifest file contains the expected bundle vendor
+ *
+ * @author Martin van Wingerden
+ */
+public class BundleVendorCheck extends AbstractStaticCheck {
+    private final static String MANIFEST_EXTENSION = "MF";
+    private static final String REQUIRED_PREFIX = "Bundle-Vendor: ";
+    private List<String> allowedValues;
+
+    public BundleVendorCheck() {
+        setFileExtensions(MANIFEST_EXTENSION);
+    }
+
+    public void setAllowedValues(String[] allowedValues) {
+        this.allowedValues = Arrays.asList(allowedValues);
+    }
+
+    @Override
+    protected void processFiltered(File file, List<String> lines) throws CheckstyleException {
+        if (isEmpty(file)) {
+            // not our task to report
+            return;
+        }
+
+        List<String> bundleVendors = lines.stream()
+                .filter(line -> line.toLowerCase().startsWith("bundle-vendor"))
+                .collect(Collectors.toList());
+
+        boolean tooMany = false;
+        if (bundleVendors.size() == 0) {
+            log(0, "\"Bundle-Vendor\" is missing");
+            return;
+        } else if (bundleVendors.size() > 1) {
+            tooMany = true;
+        }
+
+        int lineNumber = 0;
+        for (String bundleVendor : bundleVendors) {
+            lineNumber = findLineNumber(lines, bundleVendor, lineNumber);
+
+            if (tooMany) {
+                log(lineNumber, "Only one \"Bundle-Vendor\" was expected.");
+            }
+            if (!bundleVendor.startsWith(REQUIRED_PREFIX)) {
+                log(lineNumber, "Expect eg. \"Bundle-Vendor: openHAB\" got \"" + bundleVendor + "\"");
+            } else {
+                String onlyValue = bundleVendor.replace(REQUIRED_PREFIX, "");
+                if (!allowedValues.contains(onlyValue)) {
+                    log(lineNumber, "Unexpected \"" + onlyValue + "\", only allowed options: " + allowedValues);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
@@ -24,18 +24,18 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  */
 public class ExportInternalPackageCheck extends AbstractStaticCheck {
 
-    public final static String MANIFEST_EXTENSTION = "MF";
+    public final static String MANIFEST_EXTENSION = "MF";
     public final static String MESSAGE_INTERNAL_PACKAGE_EXPORTED = "Remove internal package export";
     public final static String MESSAGE_FILE_EMPTY = "File is empty !";
 
     public ExportInternalPackageCheck() {
-        setFileExtensions(MANIFEST_EXTENSTION);
+        setFileExtensions(MANIFEST_EXTENSION);
     }
 
     @Override
     protected void processFiltered(File file, List<String> lines) throws CheckstyleException {
         if (isEmpty(file)) {
-            log(0, MESSAGE_FILE_EMPTY, new Integer(0));
+            log(0, MESSAGE_FILE_EMPTY, 0);
             return;
         }
         BundleInfo manifest = parseManifestFromFile(file);
@@ -43,10 +43,10 @@ public class ExportInternalPackageCheck extends AbstractStaticCheck {
 
         int lineNumber = 0;
         for (Object export : exports) {
-            String pacakgeName = export.toString();
-            if (pacakgeName.contains(".internal")) {
-                lineNumber = findLineNumber(lines, pacakgeName, lineNumber);
-                log(lineNumber, MESSAGE_INTERNAL_PACKAGE_EXPORTED + " " + pacakgeName, new Integer(0));
+            String packageName = export.toString();
+            if (packageName.contains(".internal")) {
+                lineNumber = findLineNumber(lines, packageName, lineNumber);
+                log(lineNumber, MESSAGE_INTERNAL_PACKAGE_EXPORTED + " " + packageName, 0);
             }
         }
 

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -53,6 +53,11 @@
       <property name="severity" value="error" />
    </module>
 
+  <module name="org.openhab.tools.analysis.checkstyle.BundleVendorCheck">
+    <property name="severity" value="warning" />
+    <property name="allowedValues" value="openHAB"/>
+  </module>
+
   <module name="TreeWalker">
     <!-- See http://checkstyle.sourceforge.net/config_coding.html#IllegalThrows -->
     <module name="IllegalThrows">

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.BundleVendorCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+/**
+ * Tests for {@link BundleVendorCheck}
+ *
+ * @author Martin van Wingerden
+ */
+public class BundleVendorCheckTest extends AbstractStaticCheckTest {
+    private static final String TEST_DIRECTORY = "correctOpenHABSpellingInManifestTest/";
+    private static final DefaultConfiguration checkConfig = createCheckConfig(BundleVendorCheck.class);
+
+    @BeforeClass
+    public static void setUpClass() {
+        checkConfig.addAttribute("allowedValues", "openHAB");
+    }
+
+    @Override
+    protected DefaultConfiguration createCheckerConfig(Configuration config) {
+        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
+        configParent.addChild(config);
+        return configParent;
+    }
+
+    @Test
+    public void testEmptyFile() throws Exception {
+        verify("emptyManifest.MF",
+                generateExpectedMessages()
+        );
+
+        // we ignore this, its the responsibility of another check
+    }
+
+    @Test
+    public void testCompliantFile() throws Exception {
+        verify("compliantSample.MF",
+                generateExpectedMessages()
+        );
+    }
+
+    @Test
+    public void testMissingBundleVersion() throws Exception {
+        verify("missingBundleVersionSample.MF",
+                generateExpectedMessages(
+                        0,
+                        "\"Bundle-Vendor\" is missing"
+                )
+        );
+    }
+
+    @Test
+    public void testDoubleBundleVersion() throws Exception {
+        verify("doubleBundleVersionSample.MF",
+                generateExpectedMessages(
+                        4, "Only one \"Bundle-Vendor\" was expected.",
+                        8, "Only one \"Bundle-Vendor\" was expected."
+                )
+        );
+    }
+
+    @Test
+    public void testWrongLabelForBundleVersion() throws Exception {
+        verify("wrongKeySample.MF",
+                generateExpectedMessages(
+                        5,
+                        "Expect eg. \"Bundle-Vendor: openHAB\" got \"Bundle-vendor:openHAB\""
+                )
+        );
+    }
+
+    @Test
+    public void testWrongValueForBundleVersion() throws Exception {
+        verify("wrongValueSample.MF",
+                generateExpectedMessages(
+                        5,
+                        "Unexpected \"Openhab\", only allowed options: [openHAB]"
+                )
+        );
+    }
+
+    private void verify(String fileName, String[] expectedMessages) throws Exception {
+        verify(checkConfig,
+                getPath(TEST_DIRECTORY + fileName),
+                expectedMessages
+        );
+    }
+}

--- a/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/compliantSample.MF
+++ b/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/compliantSample.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j

--- a/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/doubleBundleVersionSample.MF
+++ b/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/doubleBundleVersionSample.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-Vendor: openHAB
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Vendor: openHAB
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j

--- a/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/missingBundleVersionSample.MF
+++ b/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/missingBundleVersionSample.MF
@@ -1,0 +1,11 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j

--- a/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/wrongKeySample.MF
+++ b/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/wrongKeySample.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-vendor:openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j

--- a/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/wrongValueSample.MF
+++ b/src/test/resources/checks/checkstyle/correctOpenHABSpellingInManifestTest/wrongValueSample.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Vendor: Openhab
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j


### PR DESCRIPTION
Add a check for proper bundle vendor, I am unsure whether the openHAB repo should contain bundles with eclipse smarthome but it does at this moment (org.openhab.binding.urtsi). 

If this test is NOT useful please let me know as well, thanks!

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>