### PR TITLE
Changed the year in the license headers from 2016 to 2017

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocFilterCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocFilterCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/MavenPomderivedInClasspathCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/MavenPomderivedInClasspathCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/MethodLimitCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/MethodLimitCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/pmd/WhileLoopsMustUseBracesRule.java
+++ b/src/main/java/org/openhab/tools/analysis/pmd/WhileLoopsMustUseBracesRule.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/tools/FindBugsChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/FindBugsChecker.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/main/java/org/openhab/tools/analysis/tools/internal/FindBugsVisitors.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/internal/FindBugsVisitors.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocFilterCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocFilterCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/MavenPomderivedInClasspathCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/MavenPomderivedInClasspathCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/MethodLimitCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/MethodLimitCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2017 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
+++ b/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
+++ b/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/src/test/java/org/openhab/tools/analysis/report/test/ReportUtilityTest.java
+++ b/src/test/java/org/openhab/tools/analysis/report/test/ReportUtilityTest.java
@@ -1,5 +1,6 @@
 /**
- * Copyright (c) 2014-2016 by the respective copyright holders.
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
As @martinvw noticed in https://github.com/openhab/static-code-analysis/pull/30 our license headers are not updated with the correct year as it is already done in openhab2-addons (https://github.com/openhab/openhab2-addons/pull/1865) and I think it is good to follow the same pattern.