### PR TITLE
Changed the severity of ExportInternalPackageCheck to error

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ For more information: https://pmd.github.io/pmd-5.4.1/customizing/rule-guideline
 2. Every bundle must contain an about.html file, providing license information. - `Work in Progress`
 3. Every bundle must contain a build.properties file, which lists all resources that should end up in the binary under bin.includes. - `Work in Progress`
 4. The manifest must not contain any “Require-Bundle” entries. Instead, “Import-Package” must be used. - [Opened PR](https://github.com/openhab/static-code-analysis/pull/19) - `severity=error`
-5. [The manifest must not export any internal package.](https://github.com/openhab/static-code-analysis/blob/master/src/main/resources/rulesets/checkstyle/rules.xml#L40) - `severity=warning`
+5. [The manifest must not export any internal package.](https://github.com/openhab/static-code-analysis/blob/master/src/main/resources/rulesets/checkstyle/rules.xml#L40) - `severity=error`
 6. The manifest must not have any version constraint on package imports, unless this is thoughtfully added. Note that Eclipse automatically adds these constraints based on the version in the target platform, which might be too high in many cases. - `Work in Progress`
 7. The manifest must include all services in the Service-Component entry. A good approach is to put OSGI-INF/*.xml in there. - `Work in Progress`
 8. Every exported package of a bundle must be imported by the bundle itself again. - `Work in Progress`

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -38,7 +38,7 @@
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.ExportInternalPackageCheck">
-    <property name="severity" value="warning" />
+    <property name="severity" value="error" />
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.MavenPomderivedInClasspathCheck">


### PR DESCRIPTION
The severity of `ExportInternalPackageCheck` should be `error` as  it is a part of ESH guidelines (https://www.eclipse.org/smarthome/documentation/development/guidelines.html).