### PR TITLE
Add a check for modifier order

### DIFF
--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -67,6 +67,10 @@
       <property name="format" value="(TODO)|(FIXME)" />
       <property name="severity" value="info" />
     </module>
+    <!-- See http://checkstyle.sourceforge.net/config_modifier.html#ModifierOrder -->
+    <module name="ModifierOrder">
+      <property name="severity" value="info" />
+    </module>
     <module name="org.openhab.tools.analysis.checkstyle.JavadocFilterCheck">
       <property name="severity" value="warning" />
       <property name="scope" value="public"/>


### PR DESCRIPTION
Since at has just been fixed in openHAB it would be nice to add the check too

See PR:
https://github.com/openhab/openhab2-addons/pull/2098
https://github.com/openhab/openhab2-addons/pull/2113

http://checkstyle.sourceforge.net/config_modifier.html#ModifierOrder

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>