### PR TITLE
Corrected some minor issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.openhab.tools</groupId>
   <artifactId>static-code-analysis</artifactId>
-  <version>0.0.3</version>
+  <version>0.0.4-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Static Code Analysis Tool</name>
@@ -20,9 +20,10 @@
     <pmd.version>5.5.1</pmd.version>
     <checkstyle.version>7.2</checkstyle.version>
     <findbugs.version>3.0.1</findbugs.version>
-    <maven.plugin.api.version>3.3.9</maven.plugin.api.version>
+    <maven.plugin.api.version>3.1.1</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.5</maven.plugin.annotations.version>
     <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
+    <maven.plugin.compiler.version>3.6.1</maven.plugin.compiler.version>
     <mojo.executor.version>2.2.0</mojo.executor.version>
     <org.apache.ivy.version>2.4.0</org.apache.ivy.version>
     <org.jsoup.version>1.7.1</org.jsoup.version>
@@ -99,6 +100,7 @@
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
       <version>${maven.plugin.annotations.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>
@@ -129,6 +131,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.plugin.compiler.version}</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
+++ b/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
@@ -333,7 +333,7 @@ public class ReportUtility extends AbstractMojo {
             FileUtils.writeStringToFile(summaryReport, reportContent);
             logger.info("Individual report appended to summary report.");
         } catch (IOException e) {
-            logger.warn("Cann't read or write to summary report. The summary report might be incomplete!", e);
+            logger.warn("Can't read or write to summary report. The summary report might be incomplete!", e);
         }
 
     }
@@ -350,7 +350,7 @@ public class ReportUtility extends AbstractMojo {
             XPathExpression expression = xPath.compile(xPathExpression);
             return (NodeList) expression.evaluate(document, XPathConstants.NODESET);
         } catch (Exception e) {
-            logger.warn("Cann't select {} nodes from {}. Empty NodeList will be returned.", xPathExpression, filePath, e);
+            logger.warn("Can't select {} nodes from {}. Empty NodeList will be returned.", xPathExpression, filePath, e);
             return new EmptyNodeList();
         }
 

--- a/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -19,6 +19,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedList;
 import java.util.List;
@@ -105,7 +106,7 @@ public abstract class AbstractChecker extends AbstractMojo {
         try {
             properties.load(inputStream);
         } catch (IOException | NullPointerException e) {
-            throw new MojoExecutionException("Can't load properties form file " + relativePath, e);
+            throw new MojoExecutionException("Can't load properties from file " + relativePath, e);
         } finally {
             try {
                 inputStream.close();
@@ -139,12 +140,10 @@ public abstract class AbstractChecker extends AbstractMojo {
      */
     protected void executeCheck(String groupId, String artifactId, String version, String goal, Xpp3Dom configuration,
             Dependency... dependencies) throws MojoExecutionException {
-        List<Dependency> deps = new ArrayList<Dependency>();
-        for (Dependency dependency : dependencies) {
-            deps.add(dependency);
-        }
+        List<Dependency> dependencyList = new ArrayList<Dependency>();
+        Collections.addAll(dependencyList, dependencies);
 
-        Plugin plugin = MojoExecutor.plugin(groupId, artifactId, version, deps);
+        Plugin plugin = MojoExecutor.plugin(groupId, artifactId, version, dependencyList);
 
         MojoExecutor.executeMojo(plugin, goal, configuration,
                 MojoExecutor.executionEnvironment(mavenProject, mavenSession, pluginManager));

--- a/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -33,7 +33,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
     /**
      * Relative path of the XML configuration to use. If not set the default ruleset file will be used -
-     * {@link #DEFAULT_RULESET_XML}
+     * {@link #DEFAULT_RULE_SET_XML}
      */
     @Parameter(property = "checkstyle.ruleset")
     protected String checkstyleRuleset;
@@ -69,40 +69,42 @@ public class CheckstyleChecker extends AbstractChecker {
     private static final String MAVEN_CHECKSTYLE_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
 
     // Default configuration file
-    private static final String DEFAULT_RULESET_XML = "rulesets/checkstyle/rules.xml";
+    private static final String DEFAULT_RULE_SET_XML = "rulesets/checkstyle/rules.xml";
     private static final String DEFAULT_FILTER_XML = "rulesets/checkstyle/suppressions.xml";
 
     /**
      * This is a property in the maven-checkstyle-plugin that is used to describe the location of the
      * ruleset file used from the plugin.
      */
-    private static final String CHECKSTYLE_RULESET_USER_PROPERTY = "checkstyle.config.location";
+    private static final String CHECKSTYLE_RULE_SET_PROPERTY = "checkstyle.config.location";
 
     /**
      * This is a property in the maven-checkstyle-plugin that is used to describe the location of the
      * suppressions file used from the plugin.
      */
-    private static final String CHECKSTYLE_SUPPRESSION_USER_PROPERTY = "checkstyle.suppressions.location";
+    private static final String CHECKSTYLE_SUPPRESSION_PROPERTY = "checkstyle.suppressions.location";
 
     @Override
     public void execute() throws MojoExecutionException {
         Log log = getLog();
-        ClassLoader cl = getMavenRuntimeClasspathClassLoader();
-        Properties userProps = loadPropertiesFromFile(cl, CHECKSTYLE_PROPERTIES_FILE);
+        ClassLoader classLoader = getMavenRuntimeClasspathClassLoader();
+        Properties userProps = loadPropertiesFromFile(classLoader, CHECKSTYLE_PROPERTIES_FILE);
 
-        String ruleset = getLocation(checkstyleRuleset, DEFAULT_RULESET_XML);
+        String ruleset = getLocation(checkstyleRuleset, DEFAULT_RULE_SET_XML);
         log.debug("Ruleset location is " + ruleset);
-        userProps.setProperty(CHECKSTYLE_RULESET_USER_PROPERTY, ruleset);
+        userProps.setProperty(CHECKSTYLE_RULE_SET_PROPERTY, ruleset);
 
         String supression = getLocation(checkstyleFilter, DEFAULT_FILTER_XML);
         log.debug("Filter location is " + supression);
-        userProps.setProperty(CHECKSTYLE_SUPPRESSION_USER_PROPERTY, supression);
+        userProps.setProperty(CHECKSTYLE_SUPPRESSION_PROPERTY, supression);
 
-        // Maven may load an older version, if I not specify any
-        Dependency checktyle = dependency("com.puppycrawl.tools", "checkstyle", "7.2");
-        Dependency[] allDependencies = getDependencies(checkstylePlugins, checktyle);
+        // Maven may load an older version, if no version is specified
+        Dependency checkstyle = dependency("com.puppycrawl.tools", "checkstyle", "7.2");
+        Dependency[] allDependencies = getDependencies(checkstylePlugins, checkstyle);
 
-        Xpp3Dom config = configuration(element("sourceDirectory", mavenProject.getBasedir().toString()));
+        Xpp3Dom config = configuration(
+                element("sourceDirectory", mavenProject.getBasedir().toString())
+        );
 
         executeCheck(MAVEN_CHECKSTYLE_PLUGIN_GROUP_ID, MAVEN_CHECKSTYLE_PLUGIN_ARTIFACT_ID, checkstyleMavenVersion,
                 MAVEN_CHECKSTYLE_PLUGIN_GOAL, config, allDependencies);


### PR DESCRIPTION
While working on fixing #45 I noted some small imperfections:
 - The pom-version is a final one and not a snapshot, openHAB also uses the rule that normally its a snapshot
 - The version for the maven compiler plugin was not specified
 - The maven plug-in annotations should have the scope provided
 - Fixed some typo's
 - Changed the explicit array to list copy to a more modern way
 - Since properties are not referring to the user properties anymore I renamed the constants

Signed-off-by: Martin van Wingerden <martinvw@mtin.nl>