### PR TITLE
Add properties to checkstyle ruleset file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Parameters:
 | **checkstyleFilter** | String | Relative path of the suppressions XML file to use. If not set the default filter file will be used |
 | **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **2.17**)|
 | **checkstylePlugins** | Dependency [] | A list with artifacts that contain additional checks for Checkstyle |
+| **checkstyleProperties** | String | Relative path of the properties file to use in the ruleset to configure specific checks |
 
 **static-code-analysis:findbugs**
 

--- a/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -58,6 +58,12 @@ public class CheckstyleChecker extends AbstractChecker {
     private Dependency[] checkstylePlugins;
 
     /**
+     * Relative path of the properties file to use in the ruleset to configure specific checks
+     */
+    @Parameter(property = "checkstyle.ruleset.properties")
+    private String checkstyleProperties;
+
+    /**
      * Location of the properties file that contains configuration options for the
      * maven-checkstyle-plugin
      */
@@ -84,6 +90,8 @@ public class CheckstyleChecker extends AbstractChecker {
      */
     private static final String CHECKSTYLE_SUPPRESSION_PROPERTY = "checkstyle.suppressions.location";
 
+    private static final String CHECKSTYLE_RULE_SET_PROPERTIES_PROPERTY = "checkstyle.properties.location";
+
     @Override
     public void execute() throws MojoExecutionException {
         Log log = getLog();
@@ -98,13 +106,17 @@ public class CheckstyleChecker extends AbstractChecker {
         log.debug("Filter location is " + supression);
         userProps.setProperty(CHECKSTYLE_SUPPRESSION_PROPERTY, supression);
 
+        if (checkstyleProperties != null) {
+            String rulesetProperties = getLocation(checkstyleProperties, "");
+            log.debug("Ruleset properties location is " + rulesetProperties);
+            userProps.setProperty(CHECKSTYLE_RULE_SET_PROPERTIES_PROPERTY, rulesetProperties);
+        }
+
         // Maven may load an older version, if no version is specified
         Dependency checkstyle = dependency("com.puppycrawl.tools", "checkstyle", "7.2");
         Dependency[] allDependencies = getDependencies(checkstylePlugins, checkstyle);
 
-        Xpp3Dom config = configuration(
-                element("sourceDirectory", mavenProject.getBasedir().toString())
-        );
+        Xpp3Dom config = configuration(element("sourceDirectory", mavenProject.getBasedir().toString()));
 
         executeCheck(MAVEN_CHECKSTYLE_PLUGIN_GROUP_ID, MAVEN_CHECKSTYLE_PLUGIN_ARTIFACT_ID, checkstyleMavenVersion,
                 MAVEN_CHECKSTYLE_PLUGIN_GOAL, config, allDependencies);

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -32,7 +32,8 @@
     <property name="ignoreLines" value="1,2,3"/>
     <property name="fileExtensions" value="java"/>
     <property name="header"
-        value="/**\n * Copyright (c) 2010-year by the respective copyright holders.\n *\n * All rights reserved. This program and the accompanying materials\n * are made available under the terms of the Eclipse Public License v1.0\n * which accompanies this distribution, and is available at\n * http://www.eclipse.org/legal/epl-v10.html\n */"/>  </module>
+        value="${checkstyle.headerCheck.content}"
+        default="/**\n * Copyright (c) 2010-year by the respective copyright holders.\n *\n * All rights reserved. This program and the accompanying materials\n * are made available under the terms of the Eclipse Public License v1.0\n * which accompanies this distribution, and is available at\n * http://www.eclipse.org/legal/epl-v10.html\n */"/>  </module>
   <module name="NewlineAtEndOfFile">
     <property name="severity" value="info"/>
   </module>
@@ -55,7 +56,7 @@
    
    <module name="org.openhab.tools.analysis.checkstyle.AboutHtmlCheck">
      <property name="severity" value="error" />
-     <property name="validAboutHtmlFileURL" value="https://raw.githubusercontent.com/openhab/openhab2-addons/master/src/etc/about.html" />
+     <property name="validAboutHtmlFileURL" value="${checkstyle.aboutHtmlCheck.url}" default="https://raw.githubusercontent.com/openhab/openhab2-addons/master/src/etc/about.html" />
    </module>
 
   <module name="org.openhab.tools.analysis.checkstyle.BundleVendorCheck">


### PR DESCRIPTION
Added possibility to add an external file with properties that can
override the configuration of checkstyle checks that have properties
specific to a repository or should be executed only on a set of bundles.

Closes #31

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>