### PR TITLE
fixed report location url

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
+++ b/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
@@ -286,8 +286,7 @@ public class ReportUtility extends AbstractMojo {
                 result.append(log);
             }
         }
-        result.append("Detailed report can be found at: file").append(File.separator).append(File.separator)
-                .append(File.separator).append(reportLocation).append("\n");
+        result.append("Detailed report can be found at: file:///").append(reportLocation).append("\n");
         return result.toString();
 
     }


### PR DESCRIPTION
The log returns an URI, which was missing the colon and which must always use forward slashes, independent of the OS.

Signed-off-by: Kai Kreuzer <kai@openhab.org>