### PR TITLE
Resource loading in MOJOs simplified.

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -10,12 +10,9 @@ package org.openhab.tools.analysis.tools;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.dependency;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -25,7 +22,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
@@ -62,46 +58,15 @@ public abstract class AbstractChecker extends AbstractMojo {
     @Parameter(defaultValue = "${plugin}", readonly = true, required = true)
     protected PluginDescriptor plugin;
 
-    private static URLClassLoader mavenRuntimeClasspathClassLoader = null;
-
-    /**
-     * Can be used to load resources from the Maven plugin project
-     *
-     * @return URLClassLoader
-     * @throws MojoExecutionException when an exception occurs during the URLClassLoader instantiation
-     */
-    protected URLClassLoader getMavenRuntimeClasspathClassLoader() throws MojoExecutionException {
-        if (mavenRuntimeClasspathClassLoader == null) {
-            try {
-                @SuppressWarnings("rawtypes")
-                List runtimeClasspathElements = mavenProject.getRuntimeClasspathElements();
-                URL[] runtimeUrls = new URL[runtimeClasspathElements.size()];
-                for (int i = 0; i < runtimeClasspathElements.size(); i++) {
-                    String element = (String) runtimeClasspathElements.get(i);
-                    runtimeUrls[i] = new File(element).toURI().toURL();
-                }
-                mavenRuntimeClasspathClassLoader = new URLClassLoader(runtimeUrls,
-                        Thread.currentThread().getContextClassLoader());
-
-            } catch (DependencyResolutionRequiredException e) {
-                throw new MojoExecutionException("Can't create custom class loader!", e);
-            } catch (MalformedURLException e) {
-                throw new MojoExecutionException("Claspathentry does not exist!", e);
-            }
-        }
-        return mavenRuntimeClasspathClassLoader;
-    }
-
     /**
      * Loads properties from file into the Maven user properties
      *
-     * @param cl - ClassLoader that can load the properties file
      * @param relativePath - relative path to the properties file
      * @return - the loaded properties
      * @throws MojoExecutionException - when the properties file can not be found or loaded
      */
-    protected Properties loadPropertiesFromFile(ClassLoader cl, String relativePath) throws MojoExecutionException {
-        InputStream inputStream = cl.getResourceAsStream(relativePath);
+    protected Properties loadPropertiesFromFile(String relativePath) throws MojoExecutionException {
+        InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(relativePath);
         Properties properties = new Properties();
         try {
             properties.load(inputStream);
@@ -201,8 +166,9 @@ public abstract class AbstractChecker extends AbstractMojo {
             Path resolvedPath = executionDir.resolve(externalDir);
             return resolvedPath.toString();
         } else {
-            URL url = getMavenRuntimeClasspathClassLoader().getResource(internalRelativePath);
+            URL url = this.getClass().getClassLoader().getResource(internalRelativePath);
             return url.toString();
         }
     }
+
 }

--- a/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -96,8 +96,7 @@ public class CheckstyleChecker extends AbstractChecker {
     @Override
     public void execute() throws MojoExecutionException {
         Log log = getLog();
-        ClassLoader classLoader = getMavenRuntimeClasspathClassLoader();
-        Properties userProps = loadPropertiesFromFile(classLoader, CHECKSTYLE_PROPERTIES_FILE);
+        Properties userProps = loadPropertiesFromFile(CHECKSTYLE_PROPERTIES_FILE);
 
         String ruleset = getLocation(checkstyleRuleset, DEFAULT_RULE_SET_XML);
         log.debug("Ruleset location is " + ruleset);

--- a/src/main/java/org/openhab/tools/analysis/tools/FindBugsChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/FindBugsChecker.java
@@ -127,8 +127,7 @@ public class FindBugsChecker extends AbstractChecker {
     public void execute() throws MojoExecutionException, MojoFailureException {
         Log log = getLog();
 
-        ClassLoader cl = getMavenRuntimeClasspathClassLoader();
-        Properties userProps = loadPropertiesFromFile(cl, FINDBUGS_PROPERTIES_FILE);
+        Properties userProps = loadPropertiesFromFile(FINDBUGS_PROPERTIES_FILE);
 
         // Load the include filter file
         String includeLocation = getLocation(findbugsInclude, DEFAULT_INCLUDE_FILTER_XML);
@@ -204,7 +203,7 @@ public class FindBugsChecker extends AbstractChecker {
                 getLog().warn("Unable to find file " + resolvedPath.toString());
             }
         } else {
-            stream = getMavenRuntimeClasspathClassLoader().getResourceAsStream(defaultLocaiton);
+            stream = this.getClass().getClassLoader().getResourceAsStream(defaultLocaiton);
 
         }
 

--- a/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -67,8 +67,7 @@ public class PmdChecker extends AbstractChecker {
     public void execute() throws MojoExecutionException, MojoFailureException {
         Log log = getLog();
 
-        ClassLoader cl = getMavenRuntimeClasspathClassLoader();
-        Properties userProps = loadPropertiesFromFile(cl, PMD_PROPERTIES_FILE);
+        Properties userProps = loadPropertiesFromFile(PMD_PROPERTIES_FILE);
 
         String rulesetLocation = getLocation(pmdRuleset, DEFAULT_RULESET_XML);
         log.debug("Ruleset location is " + rulesetLocation);


### PR DESCRIPTION
Remove the custom URLClassLoader and resource files loaded directly from the jar.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>