### PR TITLE
Removed searching for line number in MANIFEST.MF files.

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
@@ -40,11 +40,10 @@ public class ExportInternalPackageCheck extends AbstractStaticCheck {
         BundleInfo manifest = parseManifestFromFile(file);
         Set<?> exports = manifest.getExports();
 
-        int lineNumber = 0;
+        int lineNumber = findLineNumber(lines, "Export-Package:", 0);
         for (Object export : exports) {
             String packageName = export.toString();
             if (packageName.contains(".internal")) {
-                lineNumber = findLineNumber(lines, packageName, lineNumber);
                 log(lineNumber, "Remove internal package export " + packageName, 0);
             }
         }

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
@@ -12,6 +12,7 @@ import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.MANIFEST_
 
 import java.io.File;
 import java.io.IOException;
+import java.text.MessageFormat;
 import java.text.ParseException;
 import java.util.List;
 import java.util.Set;
@@ -31,7 +32,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  * @author Mihaela Memova
  */
 public class ImportExportedPackagesCheck extends AbstractStaticCheck {
-    private static final String NOT_IMPORTED_PACKAGE_MESSAGE = "The exported package is not imported";
+    private static final String NOT_IMPORTED_PACKAGE_MESSAGE = "The exported package `{0}` is not imported";
     private static final String EXPORT_PACKAGES_HEADER = "Export-Package:";
 
     private Logger logger = LoggerFactory.getLogger(this.getClass());
@@ -42,7 +43,7 @@ public class ImportExportedPackagesCheck extends AbstractStaticCheck {
 
     @Override
     protected void processFiltered(File file, List<String> lines) throws CheckstyleException {
-        int lineNumberBeforeExportsStart = findLineNumber(lines, EXPORT_PACKAGES_HEADER, 0) - 1;
+        int lineToLog = findLineNumber(lines, EXPORT_PACKAGES_HEADER, 0);
 
         try {
             Set<ExportPackage> exports = ManifestParser.parseManifest(file).getExports();
@@ -50,8 +51,7 @@ public class ImportExportedPackagesCheck extends AbstractStaticCheck {
 
             for (ExportPackage export : exports) {
                 if (!isPackageImported(imports, export)) {
-                    int lineToLog = findLineNumber(lines, export.toString(), lineNumberBeforeExportsStart);
-                    log(lineToLog, NOT_IMPORTED_PACKAGE_MESSAGE);
+                    log(lineToLog, MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, export.toString()));
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestPackageVersionCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestPackageVersionCheck.java
@@ -30,7 +30,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  *
  * @author Petar Valchev - Initial contribution.
  * @author Aleksandar Kovachev - Refactored the code and added check for exported packages.
- * @author Svlien Valkanov - Renamed the check
+ * @author Svlien Valkanov - Renamed the check, bug fixtures
  */
 public class ManifestPackageVersionCheck extends AbstractStaticCheck {
     private static final String VERSION_USED_MSG = "The version of the package %s should not be specified";
@@ -72,14 +72,25 @@ public class ManifestPackageVersionCheck extends AbstractStaticCheck {
     }
 
     private void checkVersionOfImportedPackages(BundleInfo manifest, List<String> lines) {
-        Set<BundleRequirement> imports = manifest.getRequirements();
+        Set<BundleRequirement> requiredBundles = manifest.getRequires();
+        Set<BundleRequirement> importPackages = manifest.getImports();
 
         int lineNumber = 0;
-        for (BundleRequirement requirement : imports) {
-            String requirementName = requirement.getName();
-            if (requirement.getVersion() != null && !isIgnoredPackage(ignoreImportedPackages, requirementName)) {
-                lineNumber = findLineNumber(lines, requirementName, lineNumber);
-                log(lineNumber, String.format(VERSION_USED_MSG, requirementName));
+        for (BundleRequirement importPackage : importPackages) {
+            String importName = importPackage.getName();
+            if (importPackage.getVersion() != null && !isIgnoredPackage(ignoreImportedPackages, importName)) {
+                lineNumber = findLineNumber(lines, importName, lineNumber);
+                log(lineNumber, String.format(VERSION_USED_MSG, importName));
+            }
+        }
+
+        // Start again from the beginning of the file
+        lineNumber = 0;
+        for (BundleRequirement requiredBundle : requiredBundles) {
+            if (requiredBundle.getVersion() != null) {
+                String name = requiredBundle.getName();
+                lineNumber = findLineNumber(lines, name, lineNumber);
+                log(lineNumber, String.format(VERSION_USED_MSG, name));
             }
         }
     }

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
@@ -29,7 +29,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
     private static final String TEST_DIRECTORY_NAME = "exportInternalPackageCheckTest";
-    
+
     private static DefaultConfiguration config;
 
     @Override
@@ -38,7 +38,7 @@ public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
         configParent.addChild(config);
         return configParent;
     }
-    
+
     @BeforeClass
     public static void setUpClass() {
         config = createCheckConfig(ExportInternalPackageCheck.class);
@@ -54,11 +54,10 @@ public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void testManifestFileExportsMultipleInternalPackages() throws Exception {
-        int firstLineNumber = 12;
-        int secondLineNumber = 13;
-        String[] expectedMessages = generateExpectedMessages(
-                firstLineNumber, "Remove internal package export org.eclipse.smarthome.buildtools.internal", 
-                secondLineNumber, "Remove internal package export org.eclipse.smarthome.buildtools.internal.test");
+        int lineNumber = 12;
+        String[] expectedMessages = generateExpectedMessages(lineNumber,
+                "Remove internal package export org.eclipse.smarthome.buildtools.internal", lineNumber,
+                "Remove internal package export org.eclipse.smarthome.buildtools.internal.test");
         verifyManifest("multipleInternalPackagesExported.MF", expectedMessages);
     }
 
@@ -74,8 +73,17 @@ public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
         String[] expectedMessages = CommonUtils.EMPTY_STRING_ARRAY;
         verifyManifest("noInternalPackageExported.MF", expectedMessages);
     }
-    
-    private void verifyManifest(String fileName, String[] expectedMessages) throws Exception{
+
+    @Test
+    public void testManifestJustifiedText() throws Exception {
+        int lineNumber = 13;
+        String[] expectedMessages = generateExpectedMessages(lineNumber,
+                "Remove internal package export org.eclipse.smarthome.buildtools.internal", lineNumber,
+                "Remove internal package export org.eclipse.smarthome.buildtools.internal.test");
+        verifyManifest("manifestJustifiedText.MF", expectedMessages);
+    }
+
+    private void verifyManifest(String fileName, String[] expectedMessages) throws Exception {
         String testFileRelativePath = TEST_DIRECTORY_NAME + File.separator + fileName;
         String testFileAbsolutePath = getPath(testFileRelativePath);
         verify(config, testFileAbsolutePath, expectedMessages);

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
@@ -9,6 +9,7 @@
 package org.openhab.tools.analysis.checkstyle.test;
 
 import java.io.File;
+import java.text.MessageFormat;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
     private static final String TEST_DIRECTORY_NAME = "importExportedPackagesCheckTest";
-    private static final String NOT_IMPORTED_PACKAGE_MESSAGE = "The exported package is not imported";
+    private static final String NOT_IMPORTED_PACKAGE_MESSAGE = "The exported package `{0}` is not imported";
 
     private static DefaultConfiguration configuration;
 
@@ -40,18 +41,20 @@ public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
     public void testManifestFileThatDoesNotImportAnExportedPackage() throws Exception {
         String testFileName = "ManifestNotImportingAnExportedPackage.MF";
         int lineNumber = 12;
-        String[] warningMessages = generateExpectedMessages(lineNumber, NOT_IMPORTED_PACKAGE_MESSAGE);
+        String[] warningMessages = generateExpectedMessages(lineNumber,
+                MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, "org.eclipse.smarthome.buildtools.package"));
         verifyManifestFile(testFileName, warningMessages);
     }
 
     @Test
     public void testManifestFileThatDoesNotImportSeveralExportedPackages() throws Exception {
         String testFileName = "ManifestNotImportingSeveralExportedPackages.MF";
-        int firstLineNumber = 14;
-        int secondLineNumber = 15;
+        int lineNumber = 13;
 
-        String[] warningMessages = generateExpectedMessages(firstLineNumber, NOT_IMPORTED_PACKAGE_MESSAGE,
-                secondLineNumber, NOT_IMPORTED_PACKAGE_MESSAGE);
+        String[] warningMessages = generateExpectedMessages(lineNumber,
+                MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, "org.eclipse.smarthome.buildtools.second.package"),
+                lineNumber,
+                MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, "org.eclipse.smarthome.buildtools.third.package"));
         verifyManifestFile(testFileName, warningMessages);
     }
 
@@ -60,7 +63,8 @@ public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
         String testFileName = "ManifestNotImportingAnyPackages.MF";
         int lineNumber = 10;
 
-        String[] warningMessages = generateExpectedMessages(lineNumber, NOT_IMPORTED_PACKAGE_MESSAGE);
+        String[] warningMessages = generateExpectedMessages(lineNumber,
+                MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, "org.eclipse.smarthome.buildtools.package"));
         verifyManifestFile(testFileName, warningMessages);
     }
 
@@ -68,6 +72,15 @@ public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
     public void testManifestThatImportAllExportedPackages() throws Exception {
         String testFileName = "ManifestImportingAllExportedPackages.MF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
+        verifyManifestFile(testFileName, warningMessages);
+    }
+
+    @Test
+    public void testJustifiedManifestFileThatDoesNotImportAnExportedPackage() throws Exception {
+        String testFileName = "JustifiedManifestNotImportingAnExportedPackage.MF";
+        int lineNumber = 12;
+        String[] warningMessages = generateExpectedMessages(lineNumber,
+                MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, "org.eclipse.smarthome.buildtools.package"));
         verifyManifestFile(testFileName, warningMessages);
     }
 

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
@@ -96,6 +96,16 @@ public class ManifestPackageVersionCheckTest extends AbstractStaticCheckTest {
         verifyManifest("validManifest", CommonUtils.EMPTY_STRING_ARRAY);
     }
 
+    @Test
+    public void testImportPackageAndRequireBundle() throws Exception {
+        // @formatter:off
+        String[] expectedMessages = generateExpectedMessages(
+                19,  String.format(VERSION_USED_MSG, "org.osgi.framework"),
+                20, String.format(VERSION_USED_MSG, "org.osgi.service.cm"),
+                27, String.format(VERSION_USED_MSG, "org.openhab.io.transport.mqtt"));
+        verifyManifest("testImportPackageAndRequireBundle", expectedMessages);
+    }
+
     private void verifyManifest(String testFileDirectory, String[] expectedMessages) throws Exception {
         String versionCheckTestDirectory = "manifestPackageVersionCheckTest";
         String filePath = getPath(

--- a/src/test/resources/checks/checkstyle/exportInternalPackageCheckTest/manifestJustifiedText.MF
+++ b/src/test/resources/checks/checkstyle/exportInternalPackageCheckTest/manifestJustifiedText.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ javax.xml.bind,org.eclipse.smarthome.buildtools.
+ other
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.inte
+ rnal, org.eclipse.smarthome.buildtools.internal.test,
+ org.eclipse.smarthome.buildtools.other
+

--- a/src/test/resources/checks/checkstyle/importExportedPackagesCheckTest/JustifiedManifestNotImportingAnExportedPackage.MF
+++ b/src/test/resources/checks/checkstyle/importExportedPackagesCheckTest/JustifiedManifestNotImportingAnExportedPackage.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.
+ collect, javax.xml.bind
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.
+ smarthome.buildtools.package
+

--- a/src/test/resources/checks/checkstyle/manifestPackageVersionCheckTest/testImportPackageAndRequireBundle/MANIFEST.MF
+++ b/src/test/resources/checks/checkstyle/manifestPackageVersionCheckTest/testImportPackageAndRequireBundle/MANIFEST.MF
@@ -1,0 +1,29 @@
+Manifest-Version: 1.0
+Private-Package: org.openhab.binding.mqtt.internal
+Ignore-Package: org.openhab.binding.mqtt.internal
+Bundle-Name: openHAB MQTT Binding
+Bundle-Vendor: openHAB.org
+Bundle-Version: 1.11.0.qualifier
+Bundle-ManifestVersion: 2
+Bundle-Description: This is the MQTT binding of the open Home Aut
+ omation Bus (openHAB)
+Import-Package: org.apache.commons.lang,
+ org.openhab.core.binding,
+ org.openhab.core.events,
+ org.openhab.core.items,
+ org.openhab.core.library.types,
+ org.openhab.core.transform,
+ org.openhab.core.transform.actions,
+ org.openhab.core.types,
+ org.openhab.model.item.binding,
+ org.osgi.framework;version="1.7.0",
+ org.osgi.service.cm;version="1.4.0",
+ org.slf4j
+Bundle-SymbolicName: org.openhab.binding.mqtt
+Bundle-DocURL: http://www.openhab.org
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Service-Component: OSGI-INF/mqtt-*.xml
+Bundle-ClassPath: .
+Require-Bundle: org.openhab.io.transport.mqtt;bundle-version="1.3.0"
+Export-Package: org.openhab.binding.mqtt
+Bundle-Activator: org.openhab.binding.mqtt.internal.MqttActivator


### PR DESCRIPTION
Fixes bug with not found lines when the manifest exports/imports are justified.
Closes #121

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>