### PR TITLE
Add exceptions for smarthome model bundles.

### DIFF
--- a/src/main/resources/rulesets/checkstyle/suppressions.xml
+++ b/src/main/resources/rulesets/checkstyle/suppressions.xml
@@ -18,4 +18,6 @@
     <suppress files=".+\\gen\\.+\.java" checks="AuthorTagCheck"/>
     <!-- Some checks will be supressed for test bundles -->
     <suppress files=".+.test\\.+" checks="RequireBundleCheck"/>
+    <!-- These bundles are generated trough XText -->
+    <suppress files=".+org.eclipse.smarthome.model.+" checks="RequireBundleCheck|ExportInternalPackageCheck|ManifestPackageVersionCheck|ImportExportedPackagesCheck"/>
 </suppressions>


### PR DESCRIPTION
Closes eclipse/smarthome#3926

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>