### PR TITLE
Fix false positive in PomXmlCheck.

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
@@ -40,7 +40,7 @@ import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  * @author Svilen Valkanov - Replaced headers, applied minor improvements, added check for parent pom ID
  */
 public class PomXmlCheck extends AbstractStaticCheck {
-    private static final String MISSING_VERSION_MSG = "Missing /project/parent/version in the pom.xml file.";
+    private static final String MISSING_VERSION_MSG = "Missing /project/version in the pom.xml file.";
     private static final String MISSING_ARTIFACT_ID_MSG = "Missing /project/artifactId in the pom.xml file.";
     private static final String WRONG_VERSION_MSG = "Wrong /project/parent/version in the pom.xml file. "
             + "The version should match the one in the MANIFEST.MF file.";
@@ -52,7 +52,8 @@ public class PomXmlCheck extends AbstractStaticCheck {
     private static final String DEFAULT_VERSION_REGULAR_EXPRESSION = "^\\d+[.]\\d+[.]\\d+";
     private static final String POM_ARTIFACT_ID_XPATH_EXPRESSION = "/project/artifactId/text()";
     private static final String POM_PARENT_ARTIFACT_ID_XPATH_EXPRESSION = "/project/parent/artifactId/text()";
-    private static String POM_VERSION_XPATH_EXPRESSION = "/project/parent/version/text()";
+    private static String POM_PARENT_VERSION_XPATH_EXPRESSION = "/project/parent/version/text()";
+    private static String POM_VERSION_XPATH_EXPRESSION = "/project/version/text()";
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
@@ -159,6 +160,9 @@ public class PomXmlCheck extends AbstractStaticCheck {
 
         // get the version from the pom.xml
         String versionNodeValue = getNodeValue(file, POM_VERSION_XPATH_EXPRESSION);
+        if (versionNodeValue == null) {
+            versionNodeValue = getNodeValue(file, POM_PARENT_VERSION_XPATH_EXPRESSION);
+        }
         pomVersion = getVersion(versionNodeValue, pomVersionPattern);
 
         // the version line will be preserved for finalization of the processing

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.PomXmlCheck;
@@ -33,7 +34,7 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
     private static final String POM_XML_CHECK_TEST_DIRECTORY_NAME = "pomXmlCheckTest";
     private static final String VERSION_REGULAR_EXPRESSION = "^\\d+[.]\\d+[.]\\d+";
 
-    private static final String MISSING_VERSION_MSG = "Missing /project/parent/version in the pom.xml file.";
+    private static final String MISSING_VERSION_MSG = "Missing /project/version in the pom.xml file.";
     private static final String MISSING_ARTIFACT_ID_MSG = "Missing /project/artifactId in the pom.xml file.";
     private static final String WRONG_VERSION_MSG = "Wrong /project/parent/version in the pom.xml file. "
             + "The version should match the one in the MANIFEST.MF file.";
@@ -91,6 +92,12 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
         verifyPomXmlFile("invalid_parent_pom_id_directory", parentPomIdlineNumber, formattedMessage);
     }
 
+    @Test
+    public void testMasterPom() throws Exception {
+        String testFileAbsolutePath = getPath(POM_XML_CHECK_TEST_DIRECTORY_NAME + "/pom.xml");
+        verify(createChecker(config), testFileAbsolutePath, ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
     @Override
     protected DefaultConfiguration createCheckerConfig(Configuration config) {
         DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
@@ -103,7 +110,6 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
         File testDirectory = new File(testDirectoryAbsolutePath);
         File[] testFiles = listFilesForDirectory(testDirectory, new ArrayList<File>());
         String testFilePath = testDirectory.getPath() + File.separator + POM_XML_FILE_NAME;
-
         String[] expectedMessages;
         if (expectedMessage != null) {
             expectedMessages = generateExpectedMessages(expectedLine, expectedMessage);

--- a/src/test/resources/checks/checkstyle/pomXmlCheckTest/pom.xml
+++ b/src/test/resources/checks/checkstyle/pomXmlCheckTest/pom.xml
@@ -3,14 +3,9 @@
   xmlns="http://maven.apache.org/POM/4.0.0"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-  <parent>
-    <groupId>org.openhab.binding</groupId>
-    <artifactId>master-pom</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
-  </parent>
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding</groupId>
   <artifactId>pom</artifactId>
-
+  <version>2.1.0-SNAPSHOT</version>   
+ 
 </project>


### PR DESCRIPTION
False positive was logged when the master pom is checked.
Added test case.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>