### PR TITLE
Allow certain Require-Bundle entries for test fragments

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
@@ -40,4 +40,10 @@ public class CheckConstants {
     public static final String BIN_INCLUDES_PROPERTY_NAME = "bin.includes";
     public static final String OUTPUT_PROPERTY_NAME = "output..";
     public static final String SOURCE_PROPERTY_NAME = "source..";
+
+    // OSGi MANIFEST.MF properties
+    public final static String REQUIRE_BUNDLE_HEADER_NAME = "Require-Bundle";
+    public final static String FRAGMENT_HOST_HEADER_NAME = "Fragment-Host";
+    public final static String BUNDLE_SYMBOLIC_NAME_HEADER_NAME = "Bundle-SymbolicName";
+
 }

--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -69,6 +69,7 @@
 
   <module name="org.openhab.tools.analysis.checkstyle.RequireBundleCheck">
       <property name="severity" value="error" />
+      <property name="allowedRequireBundles" value="${checkstyle.requireBundleCheck.allowedBundles}" default="org.junit,org.mockito,org.hamcrest" />
    </module>
 
    <module name="org.openhab.tools.analysis.checkstyle.AboutHtmlCheck">

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -28,22 +28,42 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class RequireBundleCheckTest extends AbstractStaticCheckTest {
     private static final String REQUIRE_BUNDLE_USED_MSG = "The MANIFEST.MF file must not contain any Require-Bundle entries. "
             + "Instead, Import-Package must be used.";
-    
+    private static final String REQUIRE_BUNDLE_TEST_USED_MSG = "The MANIFEST.MF file of a test fragment must not contain "
+            + "Require-Bundle entries other than org.junit, org.hamcrest, org.mockito.";
+
     private static DefaultConfiguration config;
 
     @BeforeClass
     public static void setUpClass() {
         config = createCheckConfig(RequireBundleCheck.class);
+
+        String allowedRequireBundles = String.format("%s,%s,%s", "org.junit", "org.hamcrest", "org.mockito");
+        config.addAttribute("allowedRequireBundles", allowedRequireBundles);
     }
 
     @Test
-    public void testExportedInternalPackage() throws Exception {
+    public void testRequireBundlePackage() throws Exception {
         verifyManifest("require_bundle_manifest_directory", "REQUIRE_BUNDLE_MANIFEST.MF", 9, REQUIRE_BUNDLE_USED_MSG);
     }
 
     @Test
     public void testValidManifest() throws Exception {
         verifyManifest("valid_manifest_directory", "VALID_MANIFEST.MF", 0, null);
+    }
+
+    @Test
+    public void testValidTestManifest() throws Exception {
+        verifyManifest("valid_test_manifest_directory", "VALID_TEST_MANIFEST.MF", 0, null);
+    }
+
+    @Test
+    public void testValidTestManifestNoRequireBundle() throws Exception {
+        verifyManifest("valid_test_manifest_directory", "VALID_TEST_MANIFEST_NO_REQUIRE_BUNDLE.MF", 0, null);
+    }
+
+    @Test
+    public void testInvalidRequireBundleTestPackage() throws Exception {
+        verifyManifest("invalid_test_manifest_directory", "INVALID_TEST_MANIFEST.MF", 13, REQUIRE_BUNDLE_TEST_USED_MSG);
     }
 
     @Override
@@ -62,7 +82,7 @@ public class RequireBundleCheckTest extends AbstractStaticCheckTest {
 
         String[] expectedMessages = null;
         if (expectedMessage != null) {
-            expectedMessages = generateExpectedMessages(expectedLine, REQUIRE_BUNDLE_USED_MSG);
+            expectedMessages = generateExpectedMessages(expectedLine, expectedMessage);
         } else {
             expectedMessages = CommonUtils.EMPTY_STRING_ARRAY;
         }

--- a/src/test/resources/checks/checkstyle/requireBundleCheckTest/invalid_test_manifest_directory/INVALID_TEST_MANIFEST.MF
+++ b/src/test/resources/checks/checkstyle/requireBundleCheckTest/invalid_test_manifest_directory/INVALID_TEST_MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example.test;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Fragment-Host: org.eclipse.smarthome.binding.example
+Import-Package: com.google.common.collect
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.other
+Require-Bundle: org.apache,org.mockito,org.hamcrest

--- a/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_test_manifest_directory/VALID_TEST_MANIFEST.MF
+++ b/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_test_manifest_directory/VALID_TEST_MANIFEST.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example.test;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Fragment-Host: org.eclipse.smarthome.binding.example
+Import-Package: com.google.common.collect
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.other
+Require-Bundle: org.junit,org.mockito,org.hamcrest

--- a/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_test_manifest_directory/VALID_TEST_MANIFEST_NO_REQUIRE_BUNDLE.MF
+++ b/src/test/resources/checks/checkstyle/requireBundleCheckTest/valid_test_manifest_directory/VALID_TEST_MANIFEST_NO_REQUIRE_BUNDLE.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Eclipse SmartHome Example 
+Bundle-SymbolicName: org.eclipse.smarthome.binding.example.test;singleton:=true
+Bundle-Vendor: Eclipse.org/SmartHome
+Bundle-Version: 0.9.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Fragment-Host: org.eclipse.smarthome.binding.example
+Import-Package: com.google.common.collect
+Service-Component: OSGI-INF/*.xml
+Export-Package: org.eclipse.smarthome.buildtools.other


### PR DESCRIPTION
According to the documentation this allows certain Require-Bundle entries in a test fragment´s MANIFEST.NF:

- The test fragment is identified from the `Fragment-Host` and `Bundle-SymbolicName` entries.
- The Require-Bundle entries are checked against `org.junit`, `org.hamcrest` and `org.mockito`.

This fixes the openHAB test fragment build, see https://github.com/openhab/openhab2-addons/pull/2516

Signed-off-by: Henning Treu <henning.treu@telekom.de>