### PR TITLE
Add analyze only property - FindBugs

### DIFF
--- a/src/main/resources/configuration/findbugs.properties
+++ b/src/main/resources/configuration/findbugs.properties
@@ -7,3 +7,5 @@ findbugs.failOnError=false
 findbugs.report.dir=target/code-analysis
 findbugs.fork=false
 outputEncoding=UTF-8
+findbugs.onlyAnalyze=org.openhab.-,org.eclipse.smarthome.-
+findbugs.nested=false


### PR DESCRIPTION
Add property to analyze only ESH and openHAB classes.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>