### PR TITLE
Restrict external libraries checks

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesExternalLibrariesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesExternalLibrariesCheck.java
@@ -7,7 +7,7 @@
  */
 package org.openhab.tools.analysis.checkstyle;
 
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.PROPERTIES_EXTENSION;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -89,6 +89,10 @@ public class BuildPropertiesExternalLibrariesCheck extends AbstractExternalLibra
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
+        if (!file.getName().equals(BUILD_PROPERTIES_FILE_NAME)) {
+            return;
+        }
+
         final String rootFolderPath = file.getParentFile().getAbsolutePath();
         final File libDirectory = new File(rootFolderPath + File.separator + LIB_FOLDER_NAME);
         String[] binIncludes = null;

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestExternalLibrariesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestExternalLibrariesCheck.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.tools.analysis.checkstyle;
 
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.MANIFEST_EXTENSION;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,6 +67,10 @@ public class ManifestExternalLibrariesCheck extends AbstractExternalLibrariesChe
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
+        if (!file.getName().equals(MANIFEST_FILE_NAME)) {
+            return;
+        }
+
         final String rootFolderPath = file.getParentFile().getParentFile().getAbsolutePath();
         final String buildPropertiesPath = rootFolderPath + File.separator + "build.properties";
         final String libFolderPath = rootFolderPath + File.separator + LIB_FOLDER_NAME;

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
@@ -8,7 +8,7 @@
  */
 package org.openhab.tools.analysis.checkstyle;
 
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.PROPERTIES_EXTENSION;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -58,6 +58,9 @@ public class OutsideOfLibExternalLibrariesCheck extends AbstractExternalLibrarie
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
+        if (!file.getName().equals(BUILD_PROPERTIES_FILE_NAME)) {
+            return;
+        }
         File bundleDirectory = file.getParentFile();
         checkBundleForOutOfPlaceJarFiles(bundleDirectory, LIB_FOLDER_NAME);
     }


### PR DESCRIPTION
Unexpected errors occurr when the checker visits files with the same extension

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>