### PR TITLE
Make check PackageExportsNameCheck work on none Windows system too.

### DIFF
--- a/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/src/main/resources/rulesets/checkstyle/rules.xml
@@ -135,7 +135,7 @@
   
   <module name="org.openhab.tools.analysis.checkstyle.PackageExportsNameCheck">
     <property name="severity" value="warning" />
-    <property name="sourceDirectories" value="src\main\java" />
+    <property name="sourceDirectories" value="src/main/java" />
     <property name="excludedPackages" value=".*.internal.*" />
   </module>
 


### PR DESCRIPTION
backward slashes don't work well on none Windows systems.
Fix related to pr #102

Signed-off-by: Hilbrand Bouwkamp <hilbrand@h72.nl> (github: Hilbrand)