### PR TITLE
Maximum memory allocation in Travis build slightly updated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk: oraclejdk8
+before_install: echo "MAVEN_OPTS='-Xmx128m'" > ~/.mavenrc
 
 install:
   - echo 'mvn clean install -B -V 1> .build.stdout 2> .build.stderr' > .build.sh


### PR DESCRIPTION
The default value of 32MB is a bit less for the tests after adding Jetty server for the unit tests in #170

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>