### PR TITLE
Added a better message for the OutsideOfLibExternalLibrariesCheck tha…

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
@@ -29,7 +29,8 @@ import edu.emory.mathcs.backport.java.util.Arrays;
  */
 public class OutsideOfLibExternalLibrariesCheck extends AbstractExternalLibrariesCheck {
     private List<String> ignoredDirectories;
-    private static final String JAR_FILES_NEED_TO_BE_PLACED_IN_A_LIB_FOLDER = "All jar files need to be placed inside a lib folder and added to MANIFEST.MF and build.properties";
+    private static final String JAR_FILES_NEED_TO_BE_PLACED_IN_A_LIB_FOLDER = "There is a jar outside of the lib folder %s"
+            + File.separator + "%s";
 
     public OutsideOfLibExternalLibrariesCheck() {
         setFileExtensions(PROPERTIES_EXTENSION);
@@ -49,7 +50,7 @@ public class OutsideOfLibExternalLibrariesCheck extends AbstractExternalLibrarie
                 }
 
                 if (name.endsWith(JAR_FILE_EXTENSION)) {
-                    log(0, JAR_FILES_NEED_TO_BE_PLACED_IN_A_LIB_FOLDER);
+                    log(0, String.format(JAR_FILES_NEED_TO_BE_PLACED_IN_A_LIB_FOLDER, dir.getAbsolutePath(), name));
                 }
 
                 return dir.isDirectory();

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
@@ -61,8 +61,10 @@ public class OutsideOfLibExternalLibrariesCheckTest extends AbstractStaticCheckT
     public void shouldLogWhenThereAreJarFilesOutsideOfLibFolder() throws Exception {
         final String BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER = MAIN_DIRECTORY + File.separator
                 + "bundleWithJarFilesOutsideOfLib";
-        String message = "All jar files need to be placed inside a lib folder and added to MANIFEST.MF and build.properties";
-        String[] warningMessages = generateExpectedMessages(0, message);
+        final String JAR_PATH = getPath(BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER);
+        String message = "There is a jar outside of the lib folder %s" + File.separator + "%s";
+
+        String[] warningMessages = generateExpectedMessages(0, String.format(message, JAR_PATH, "test3.jar"));
         verifyBuildProperties(getBuildPropertiesPath(BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER), warningMessages);
     }
 


### PR DESCRIPTION
…t contains the path to the file and the name of the jar.

See #190

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>