### PR TITLE
Fixed a problem where the ParameterizedRegexpHeaderCheck would not di…

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
@@ -8,8 +8,7 @@
  */
 package org.openhab.tools.analysis.checkstyle;
 
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.JAVA_EXTENSION;
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.XML_EXTENSION;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
 import java.text.MessageFormat;
@@ -38,7 +37,7 @@ public class ParameterizedRegexpHeaderCheck extends AbstractHeaderCheck {
     public static final String DEFAULT_XML_START_COMMENT = "<!--";
 
     private static final String SEPARATOR = "\n";
-    private static final String MSG_MISMATCH = "Header line doesn't match pattern {0}";
+    private static final String MSG_MISMATCH = "Header line doesn''t match pattern {0}";
     private static final String MSG_MISSING = "Header is missing";
 
     /**
@@ -102,7 +101,7 @@ public class ParameterizedRegexpHeaderCheck extends AbstractHeaderCheck {
 
             for (int i = 0; i < referenceHeaderLines.size(); i++) {
                 if (!isMatch(fileText.get(i), i)) {
-                    log(i + 1, MessageFormat.format(MSG_MISMATCH, headerRegexps.get(i).pattern()));
+                    log(i + 1, MSG_MISMATCH, headerRegexps.get(i).pattern());
                     break;
                 }
             }

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
@@ -26,7 +26,7 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  * @author Svilen Valkanov - Initial contribution
  */
 public class ParameterizedRegexpHeaderCheckTest extends AbstractStaticCheckTest {
-    private static final String MSG_MISMATCH = "Header line doesn't match pattern {0}";
+    private static final String MSG_MISMATCH = "Header line doesn''t match pattern {0}";
     private static final String MSG_MISSING = "Header is missing";
 
     private static final String TEST_DIRECOTRY = "parameterizedRegexpHeaderCheckTest";


### PR DESCRIPTION
…splay the pattern in the error message properly.

It used to display the error message without properly formatting the pattern like this:
`Header line doesnt match pattern {0}`.

With this change it formats it correctly.
You can see a familiar issue [here](https://stackoverflow.com/questions/17569608/format-a-message-using-messageformat-format-in-java)

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>