### PR TITLE
Fix inappropriate warning logs.

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
@@ -41,14 +41,16 @@ public class ExportInternalPackageCheck extends AbstractStaticCheck {
         BundleInfo manifest = parseManifestFromFile(fileText);
         Set<?> exports = manifest.getExports();
 
-        int lineNumber = findLineNumberSafe(fileText, EXPORT_PACKAGE_HEADER_NAME, 0, "Header line number not found.");
+        if (!exports.isEmpty()) {
+            int lineNumber = findLineNumberSafe(fileText, EXPORT_PACKAGE_HEADER_NAME, 0,
+                    "Header line number not found.");
 
-        for (Object export : exports) {
-            String packageName = export.toString();
-            if (packageName.contains(".internal")) {
-                log(lineNumber, "Remove internal package export " + packageName, 0);
+            for (Object export : exports) {
+                String packageName = export.toString();
+                if (packageName.contains(".internal")) {
+                    log(lineNumber, "Remove internal package export " + packageName, 0);
+                }
             }
         }
-
     }
 }

--- a/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
@@ -43,18 +43,21 @@ public class ImportExportedPackagesCheck extends AbstractStaticCheck {
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
-        int lineToLog = findLineNumberSafe(fileText, EXPORT_PACKAGE_HEADER_NAME, 0,
-                EXPORT_PACKAGE_HEADER_NAME + " header line number not found.");
-
         try {
             Set<ExportPackage> exports = ManifestParser.parseManifest(file).getExports();
             Set<BundleRequirement> imports = ManifestParser.parseManifest(file).getImports();
 
-            for (ExportPackage export : exports) {
-                if (!isPackageImported(imports, export)) {
-                    log(lineToLog, MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, export.toString()));
+            if (!exports.isEmpty()) {
+                int lineToLog = findLineNumberSafe(fileText, EXPORT_PACKAGE_HEADER_NAME, 0,
+                        EXPORT_PACKAGE_HEADER_NAME + " header line number not found.");
+
+                for (ExportPackage export : exports) {
+                    if (!isPackageImported(imports, export)) {
+                        log(lineToLog, MessageFormat.format(NOT_IMPORTED_PACKAGE_MESSAGE, export.toString()));
+                    }
                 }
             }
+
         } catch (IOException e) {
             logger.error("An error occured while processing the file " + file.getPath(), e);
         } catch (ParseException e) {


### PR DESCRIPTION
ImportExportedPackageCheck always searched for Export-Package header,
even when no packages were exported. This caused warning logs in
bundles where no packages are exported.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>