### PR TITLE
fix escaped symbols breaking markdown checks

### DIFF
--- a/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
+++ b/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
@@ -8,8 +8,11 @@
  */
 package org.openhab.tools.analysis.checkstyle.readme;
 
+import java.util.function.Function;
+
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
 import org.openhab.tools.analysis.checkstyle.api.NoResultException;
+import org.openhab.tools.analysis.utils.LineFormatterFunction;
 
 import com.puppycrawl.tools.checkstyle.api.FileText;
 
@@ -26,10 +29,11 @@ public interface MarkdownVisitorCallback {
      * @param fileContent - the file content represented in a list
      * @param searchedText - the searched text in the source
      * @param startLineNumber - the line number to start the search from
+     * @param lineFormatterFunction - a formatting function to apply to every line
      * @throws NoResultException when no match was found
      * @return - returns the line number in the source file
      */
-    public int findLineNumber(FileText fileContent, String searchedText, int startLineNumber) throws NoResultException;
+    public int findLineNumber(FileText fileContent, String searchedText, int startLineNumber, LineFormatterFunction lineFormatterFunction) throws NoResultException;
 
     /**
      * This method is implemented in The {@link MarkdownCheck} class calling the protected log() of

--- a/src/main/java/org/openhab/tools/analysis/utils/LineFormatterFunction.java
+++ b/src/main/java/org/openhab/tools/analysis/utils/LineFormatterFunction.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.utils;
+
+import org.openhab.tools.analysis.checkstyle.readme.MarkdownCheck;
+
+/**
+ * A callback interface for {@link MarkdownCheck}
+ *
+ * @author Lyubomir Papazov - initial contribution
+ *
+ */
+@FunctionalInterface
+public interface LineFormatterFunction {
+    /**
+     * Used in AbstractStaticCheck's findLineNumber method to apply rules
+     * about escaping special characters to a line in the markdown file
+     *
+     * @param line - an unparsed line from the markdown file
+     * @return the line after formatting has been applied to it
+     */
+    public String formatLine(String line);
+}

--- a/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -10,15 +10,17 @@ package org.openhab.tools.analysis.checkstyle.test;
 
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_STRING_ARRAY;
 import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.README_MD_FILE_NAME;
-import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
-import org.openhab.tools.analysis.checkstyle.readme.MarkdownCheck;
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
+
 import java.io.File;
 import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import org.openhab.tools.analysis.checkstyle.readme.MarkdownCheck;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Tests for {@link MarkdownCheck}
@@ -42,7 +44,6 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
         verifyMarkDownFile("testHeader", expectedMessages);
     }
 
-    
     @Test
     public void testForbiddNodeVisit() throws Exception {
         verifyMarkDownFile("testForbiddenNodeVisit", noMessagesExpected());
@@ -55,7 +56,8 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void headerAtEndOfFile() throws Exception {
-        String[] expectedMessages = generateExpectedMessages(6, "There is a header at the end of the Markdown file. Please consider adding some content below.");
+        String[] expectedMessages = generateExpectedMessages(6,
+                "There is a header at the end of the Markdown file. Please consider adding some content below.");
         verifyMarkDownFile("testHeaderAtEndOfFile", expectedMessages);
     }
 
@@ -84,6 +86,31 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testCodeFormattedListBlock() throws Exception {
         verifyMarkDownFile("testCodeFormattedListBlock", noMessagesExpected());
+    }
+    
+    @Test
+    public void testEscapedAsterisk() throws Exception {
+    	verifyMarkDownFile("testEscapedAsterisk", noMessagesExpected());
+    }
+    
+    @Test
+    public void testEscapedUnderscore() throws Exception {
+    	verifyMarkDownFile("testEscapedUnderscore", noMessagesExpected());
+    }
+    
+    @Test
+    public void testEscapedBrackets() throws Exception {
+    	verifyMarkDownFile("testEscapedBrackets", noMessagesExpected());
+    }
+    
+    @Test
+    public void testEscapedCopyrightSymbol() throws Exception {
+    	verifyMarkDownFile("testEscapedCopyrightSymbol", noMessagesExpected());
+    }
+    
+    @Test
+    public void testEscapedHeader() throws Exception {
+    	verifyMarkDownFile("testEscapedHeader", noMessagesExpected());
     }
 
     @Test
@@ -128,7 +155,7 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void testCodeSectionLineNumberError() throws Exception {
-        verifyMarkDownFile("testCodeSectionLineNumberError",noMessagesExpected());
+        verifyMarkDownFile("testCodeSectionLineNumberError", noMessagesExpected());
     }
 
     @Test
@@ -210,8 +237,9 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyBuildProperties(String[] expectedMessages, String testDirectoryName)
-            throws IOException, Exception { 
-        String testDirectoryAbsolutePath = getPath(README_MD_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName);
+            throws IOException, Exception {
+        String testDirectoryAbsolutePath = getPath(
+                README_MD_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName);
         String messageFilePath = testDirectoryAbsolutePath + File.separator + "build.properties";
         verify(createChecker(config), messageFilePath, expectedMessages);
     }

--- a/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedAsterisk/README.md
+++ b/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedAsterisk/README.md
@@ -1,0 +1,3 @@
+#### Title
+
+ * Escaped\*Asterisk

--- a/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedBrackets/README.md
+++ b/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedBrackets/README.md
@@ -1,0 +1,3 @@
+#### Title
+
+\[This is not a link\](not a link)

--- a/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedCopyrightSymbol/README.md
+++ b/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedCopyrightSymbol/README.md
@@ -1,0 +1,4 @@
+#### Example list
+
+ * first
+ * \&copy; 

--- a/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedHeader/README.md
+++ b/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedHeader/README.md
@@ -1,0 +1,3 @@
+#### Configuration Options
+
+\#### Not a header in the last line

--- a/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedUnderscore/README.md
+++ b/src/test/resources/checks/checkstyle/markdownCheckTest/testEscapedUnderscore/README.md
@@ -1,0 +1,25 @@
+#### Configuration Options
+
+ * deviceId - Device Id
+    * Device Id. House code + unit code, separated by dot. Example A.1
+
+ * subType - Sub Type
+    * Specifies device sub type.
+
+        * X10 - X10 lighting
+        * ARC - ARC
+        * AB400D - ELRO AB400D (Flamingo)
+        * WAVEMAN - Waveman
+        * EMW200 - Chacon EMW200
+        * IMPULS - IMPULS
+        * RISINGSUN - RisingSun
+        * PHILIPS - Philips SBC
+        * ENERGENIE - Energenie ENER010
+        * ENERGENIE\_5 - Energenie 5-gang
+        * COCO - COCO GDR2-2000R
+        * HQ\_COCO20 - HQ COCO-20
+
+
+### lighting2 - RFXCOM Lighting2 Actuator
+
+A Lighting2 device.


### PR DESCRIPTION
Create a fix for [issue #205 ](https://github.com/openhab/static-code-analysis/issues/205).

Fix a single backslash before special symbols (!"#$%&\'()*+,./:;<=>?@][\^_`{|}~-) not escaping that symbol in .markdown files.
