### PR TITLE
Add check to generate warning if ThingHandler sets Thing label

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ThingHandlerSetLabelCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ThingHandlerSetLabelCheck.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.JAVA_EXTENSION;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.Queue;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+
+import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
+
+import antlr.RecognitionException;
+import antlr.TokenStreamException;
+
+/**
+ * Checks the code and generates a warning if a class extends BaseThingHandler
+ * and the instance method setLabel of the Thing interface is used.
+ * The label have to be set only by the user.
+ *
+ * @author Tanya Georgieva - Initial Contribution
+ */
+public class ThingHandlerSetLabelCheck extends AbstractStaticCheck {
+
+    private static final String WARNING_MESSAGE = "Do not use the setLabel of the thing in the ThingHandler";
+    private static final String BASE_THING_HANDLER = "BaseThingHandler";
+    private static final String SEARCHED_PACKAGE = "org.eclipse.smarthome.core.thing.binding." + BASE_THING_HANDLER;
+    private static final String SET_LABEL = "setLabel";
+    private static final String THING = "thing";
+    private static final String UNKNOWN = "UNKNOWN";
+
+    private final Log logger = LogFactory.getLog(ThingHandlerSetLabelCheck.class);
+
+    private String fullJavaExtension = "\\." + JAVA_EXTENSION;
+
+    private HashMap<File, DetailAST> files;
+    private HashMap<File, String> derivedAndBaseClasses;
+    private HashMap<File, DetailAST> classesExtendingBaseThingHandler;
+
+    public ThingHandlerSetLabelCheck() {
+        setFileExtensions(JAVA_EXTENSION);
+    }
+
+    @Override
+    public void init() {
+        files = new HashMap<>();
+        derivedAndBaseClasses = new HashMap<>();
+        classesExtendingBaseThingHandler = new HashMap<>();
+    }
+
+    @Override
+    protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
+        FileContents fileContents = new FileContents(fileText);
+        DetailAST rootAST = null;
+
+        try {
+            rootAST = TreeWalker.parse(fileContents);
+        } catch (RecognitionException | TokenStreamException e) {
+            logger.error("Parsing file not successful");
+            e.printStackTrace();
+        }
+        files.put(file, rootAST);
+    }
+
+    @Override
+    public void finishProcessing() {
+        findDerivedAndBaseClasses();
+        findClassesExtendingBaseThingHandler();
+
+        classesExtendingBaseThingHandler.forEach((file, rootAST) -> {
+            String fileName = file.getName();
+            Path filePath = file.toPath();
+            checkSetLabelMethodCall(rootAST, fileName, filePath);
+        });
+    }
+
+    // Pre-order traversal - starting from the root first
+    private void checkSetLabelMethodCall(DetailAST nodeAST, String fileName, Path filePath) {
+        if (nodeAST == null) {
+            return;
+        }
+
+        if (THING.equals(nodeAST.getText())) {
+            // thing.setLabel(...)
+            boolean isThingFieldSetLabelMethodCalled = nodeAST.getNextSibling() != null
+                    && SET_LABEL.equals(nodeAST.getNextSibling().getText());
+            // when literal THIS is used the setLabel method is sibling of the parent of the node - thing
+            // this.thing.setLabel(...)
+            boolean isReferredThingFieldSetLabelMethodCalled = nodeAST.getParent().getNextSibling() != null
+                    && SET_LABEL.equals(nodeAST.getParent().getNextSibling().getText());
+            boolean isSetLabelCalled = isThingFieldSetLabelMethodCalled || isReferredThingFieldSetLabelMethodCalled;
+
+            if (isSetLabelCalled) {
+                int nodeLineNumber = nodeAST.getLineNo();
+                String fileStringPath = filePath.toString();
+                logMessage(fileStringPath, nodeLineNumber, fileName, WARNING_MESSAGE);
+            }
+        }
+        checkSetLabelMethodCall(nodeAST.getFirstChild(), fileName, filePath);
+        checkSetLabelMethodCall(nodeAST.getNextSibling(), fileName, filePath);
+    }
+
+    public void findClassesExtendingBaseThingHandler() {
+        Queue<File> visitedFiles = new LinkedList<>();
+        File searchedPackageFile = new File(SEARCHED_PACKAGE);
+        visitedFiles.add(searchedPackageFile);
+
+        while (!visitedFiles.isEmpty()) {
+            File currentFile = visitedFiles.poll();
+            String currentFileParent = currentFile.getParent();
+            String currentFileClassName = currentFile.getName().replaceFirst(fullJavaExtension, "");
+
+            derivedAndBaseClasses.forEach((file, baseClassName) -> {
+                String fileParent = file.getParent();
+                // Check if the current class and it's base class are from the same package.
+                // To find first the classes extending BaseThingHandler directly,
+                // we set the first file to be the SEARCHED PACKAGE,
+                // it's parent is null so the check is for the currentFileClassName
+                boolean areFilesFromSamePackage = SEARCHED_PACKAGE.equals(currentFileClassName)
+                        || currentFileParent.equals(fileParent);
+
+                if (currentFileClassName.equals(baseClassName) && areFilesFromSamePackage) {
+                    DetailAST fileRootAST = files.get(file);
+                    classesExtendingBaseThingHandler.put(file, fileRootAST);
+                    visitedFiles.add(file);
+                }
+            });
+        }
+    }
+
+    private void findDerivedAndBaseClasses() {
+        files.forEach((file, rootAST) -> {
+            Optional<String> fullyQualifiedName = getFullyQualifiedName(rootAST);
+            Optional<String> baseClassName = getBaseClassName(rootAST);
+            String currentFullName = fullyQualifiedName.orElse(UNKNOWN);
+            String currentBaseName = baseClassName.orElse(UNKNOWN);
+            // if the currentFullName is not UNKNOWN our SEARCHED PACKAGE is found for the current class
+            boolean isHandlerImportsBaseThingHanlderPackage = !UNKNOWN.equals(currentFullName);
+            // check for case where the SEARCHED PACKAGE is imported but not extended
+            boolean isHandlerExtendingBaseThingHandler = !UNKNOWN.equals(currentBaseName)
+                    && BASE_THING_HANDLER.equals(currentBaseName);
+
+            if (isHandlerImportsBaseThingHanlderPackage && isHandlerExtendingBaseThingHandler) {
+                derivedAndBaseClasses.put(file, currentFullName);
+            } else {
+                derivedAndBaseClasses.put(file, currentBaseName);
+            }
+        });
+    }
+
+    private Optional<String> getFullyQualifiedName(DetailAST rootAST) {
+        Queue<DetailAST> visitedNodes = new LinkedList<>();
+        visitedNodes.add(rootAST);
+
+        while (!visitedNodes.isEmpty()) {
+            DetailAST currentNode = visitedNodes.poll();
+            String currentFullName = CheckUtils.createFullType(currentNode).getText();
+
+            if (SEARCHED_PACKAGE.equals(currentFullName)) {
+                return Optional.of(SEARCHED_PACKAGE);
+            } else {
+                if (currentNode.getNextSibling() != null) {
+                    visitedNodes.add(currentNode.getNextSibling());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getBaseClassName(DetailAST rootAST) {
+        Queue<DetailAST> visitedNodes = new LinkedList<>();
+        visitedNodes.add(rootAST);
+
+        while (!visitedNodes.isEmpty()) {
+            DetailAST currentNode = visitedNodes.poll();
+
+            if (currentNode.getType() == TokenTypes.CLASS_DEF) {
+                DetailAST extendsClause = currentNode.findFirstToken(TokenTypes.EXTENDS_CLAUSE);
+
+                if (extendsClause != null) {
+                    String inheritedClassName = extendsClause.getFirstChild().getText();
+                    // Only the simple name of the class can be retrieved from the extends clause
+                    return Optional.of(inheritedClassName);
+                }
+            } else {
+                if (currentNode.getNextSibling() != null) {
+                    visitedNodes.add(currentNode.getNextSibling());
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ThingHandlerSetLabelCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ThingHandlerSetLabelCheckTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ThingHandlerSetLabelCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.google.common.collect.Maps;
+import com.puppycrawl.tools.checkstyle.BriefUtLogger;
+import com.puppycrawl.tools.checkstyle.Checker;
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link ThingHandlerSetLabelCheck}
+ *
+ * @author Tanya Georgieva - Initial Contribution
+ */
+public class ThingHandlerSetLabelCheckTest extends AbstractStaticCheckTest {
+
+    private static final String TEST_DIRECTORY_NAME = "thingHandlerSetLabelCheckTest";
+    private static final String WARNING_MESSAGE = "Do not use the setLabel of the thing in the ThingHandler";
+
+    private static DefaultConfiguration config = createCheckConfig(ThingHandlerSetLabelCheck.class);
+
+    private static final String BINDING_BASE_HANDLER = "org.openhab.binding.base.handler";
+    private static final String BINDING_EXTENDING_HANDLER = "org.openhab.binding.extending.handler";
+    private static final String BINDING_IMPORT_ONLY = "org.openhab.binding.import.only";
+    private static final String BINDING_NOT_EXTENDING_HANDLER = "org.openhab.binding.notextending.handler";
+    private static final String BINDING_THING_HANDLER = "org.openhab.binding.thing.handler";
+    private static final String BINDING_THING_FIELD = "org.openhabl.binding.thing.field";
+
+    private TreeMap<File, String[]> filesWithWarnings;
+
+    private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+    @Override
+    public BriefUtLogger getBriefUtLogger() {
+        return new BriefUtLogger(stream);
+    }
+
+    @Override
+    protected DefaultConfiguration createCheckerConfig(Configuration config) {
+        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
+        configParent.addChild(config);
+        return configParent;
+    }
+
+    @Before
+    public void initializeMap() {
+        filesWithWarnings = new TreeMap<>();
+    }
+
+    @Test
+    public void verifyBindingExtendingHandlerPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_EXTENDING_HANDLER, "ThingHandlerWithSetLabel.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ThingHandlerExtendingIndirectlyIncorrectBTH.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ThingHandlerExtendingIncorrectClass.java",
+                CommonUtils.EMPTY_STRING_ARRAY);
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    @Test
+    public void verifyBindingImportOnlyPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_IMPORT_ONLY, "ThingHandlerWithImportBaseThingHandlerOnly.java",
+                CommonUtils.EMPTY_STRING_ARRAY);
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    @Test
+    public void verifyBindingNotExtendingHandlerPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_NOT_EXTENDING_HANDLER, "ThingHandlerExtendingIncorrectChildOfBTH.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ThingHandlerWithIncorrectBaseThingHandlerPackage.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ClassWithoutHandlerAndSetLabel.java", CommonUtils.EMPTY_STRING_ARRAY);
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    @Test
+    public void verifyBindingThingFieldPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_THING_FIELD, "ThingHandlerWithoutThingFieldWithSetLabel.java",
+                CommonUtils.EMPTY_STRING_ARRAY);
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    @Test
+    public void verifyBindingBaseHandlerPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_BASE_HANDLER, "ThingHandlerExtendingIndirectChildOfBTH.java",
+                generateExpectedMessages(14, WARNING_MESSAGE), "ThingHandlerWithSetLabel.java",
+                generateExpectedMessages(15, WARNING_MESSAGE), "ThingHandlerExtendingIndirectlyBTH.java",
+                generateExpectedMessages(14, WARNING_MESSAGE));
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    @Test
+    public void verifyBindingThingHandlerPackage() throws Exception {
+        filesWithWarnings = generateMap(BINDING_THING_HANDLER, "ThingHandlerWithThingFieldWithoutSetLabel.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ThingHandlerWithSetLabelWithLiteralThis.java",
+                generateExpectedMessages(15, WARNING_MESSAGE), "ThingHandlerWithoutSetLabel.java",
+                CommonUtils.EMPTY_STRING_ARRAY, "ThingHandlerWithMultipleSetLabel.java",
+                generateExpectedMessages(17, WARNING_MESSAGE, 21, WARNING_MESSAGE));
+
+        verifyMapFiles(createChecker(config), filesWithWarnings);
+    }
+
+    protected TreeMap<File, String[]> generateMap(String directoryName, Object... arguments) throws Exception {
+        String filePath = getFilePath(directoryName);
+        int filesNumber = arguments.length / 2;
+        TreeMap<File, String[]> generatedMap = new TreeMap<>();
+
+        for (int i = 0; i < filesNumber; i++) {
+            File file = new File(filePath + arguments[2 * i]);
+            String[] messages = (String[]) arguments[2 * i + 1];
+            generatedMap.put(file, messages);
+        }
+        return generatedMap;
+    }
+
+    private String getFilePath(String fileDirectory) throws Exception {
+        String testDirectoryRelativePath = TEST_DIRECTORY_NAME + File.separator + fileDirectory;
+        String testDirectoryAbsolutePath = getPath(testDirectoryRelativePath);
+        File testDirectory = new File(testDirectoryAbsolutePath);
+        String filePath = testDirectory + File.separator;
+        return filePath;
+    }
+
+    /**
+     * Custom verify to perform verification of files represented as keys in the given TreeMap<File, String[]>.
+     * Values are arrays of the expected messages with their line numbers.
+     * Using TreeMap structure because of its natural ordering of the keys
+     * (in the method we order the actual messages as well.Check below: final List<String> actuals).
+     *
+     * @param checker {@link Checker} instance.
+     * @param collectedFiles files to verify
+     * @throws Exception if exception occurs during verification process.
+     */
+    private void verifyMapFiles(Checker checker, TreeMap<File, String[]> collectedFiles) throws Exception {
+        stream.flush();
+        // filter the files which string array is not empty
+        final Map<File, String[]> expectedFiles = Maps.filterValues(collectedFiles,
+                expectedMessages -> expectedMessages.length > 0);
+
+        File[] processedFiles = expectedFiles.keySet().toArray(new File[] {});
+        final ArrayList<File> theFiles = new ArrayList<>();
+        Collections.addAll(theFiles, processedFiles);
+        final int errs = checker.process(theFiles);
+
+        // process each of the lines
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(stream.toByteArray());
+
+        try (LineNumberReader lnr = new LineNumberReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
+
+            final int expectedMessagesCount = expectedFiles.values().stream().distinct()
+                    .mapToInt(messages -> messages.length).sum();
+
+            final List<String> actuals = lnr.lines().limit(expectedMessagesCount).sorted().collect(Collectors.toList());
+            int msgNo = 0;
+
+            for (Map.Entry<File, String[]> entry : expectedFiles.entrySet()) {
+                String file = entry.getKey().toString();
+                String[] messages = entry.getValue();
+                for (String message : messages) {
+                    final String expectedResult = file + ":" + message;
+                    assertEquals("error message " + msgNo, expectedResult, actuals.get(msgNo));
+                    msgNo++;
+                }
+            }
+            assertEquals("unexpected output: " + lnr.readLine(), expectedMessagesCount, errs);
+        }
+        checker.destroy();
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerExtendingIndirectChildOfBTH.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerExtendingIndirectChildOfBTH.java
@@ -1,0 +1,16 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerExtendingIndirectChildOfBTH extends ThingHandlerExtendingIndirectlyBTH{
+
+    public ThingHandlerExtendingIndirectChildOfBTH(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerExtendingIndirectlyBTH.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerExtendingIndirectlyBTH.java
@@ -1,0 +1,16 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerExtendingIndirectlyBTH extends ThingHandlerWithSetLabel{
+
+    public ThingHandlerExtendingIndirectlyBTH(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerWithSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.base.handler/ThingHandlerWithSetLabel.java
@@ -1,0 +1,17 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithSetLabel extends BaseThingHandler {
+
+    public ThingHandlerWithSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerExtendingIncorrectClass.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerExtendingIncorrectClass.java
@@ -1,0 +1,18 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.example.test.core.thing.binding.ExampleAbstractClass;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerExtendingIncorrectClass extends ExampleAbstractClass{
+
+    public ThingHandlerExtendingIncorrectClass(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void exampleMethod() {
+        // Empty - for the purpose of the test
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerExtendingIndirectlyIncorrectBTH.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerExtendingIndirectlyIncorrectBTH.java
@@ -1,0 +1,16 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerExtendingIndirectlyIncorrectBTH extends ThingHandlerWithSetLabel{
+
+    public ThingHandlerExtendingIndirectlyBTH(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerWithSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.extending.handler/ThingHandlerWithSetLabel.java
@@ -1,0 +1,18 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.test.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+// class with duplicate name extending incorrect BaseThingHandler
+public class ThingHandlerWithSetLabel extends BaseThingHandler {
+
+    public ThingHandlerWithSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.import.only/ThingHandlerWithImportBaseThingHandlerOnly.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.import.only/ThingHandlerWithImportBaseThingHandlerOnly.java
@@ -1,0 +1,5 @@
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+
+public class ThingHandlerWithImportBaseThingHandlerOnly {
+    // Empty - for the purpose of the test
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ClassWithoutHandlerAndSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ClassWithoutHandlerAndSetLabel.java
@@ -1,0 +1,4 @@
+public class ClassWithoutHandlerAndSetLabel {
+    // Empty - for the purpose of the test
+}
+

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ThingHandlerExtendingIncorrectChildOfBTH.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ThingHandlerExtendingIncorrectChildOfBTH.java
@@ -1,0 +1,22 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerExtendingIncorrectChildOfBTH extends ThingHandlerWithIncorrectBaseThingHandlerPackage {
+
+    private String label;
+
+    public ThingHandlerExtendingIncorrectChildOfBTH(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        setLabel("Label");
+    }
+
+    private void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ThingHandlerWithIncorrectBaseThingHandlerPackage.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.notextending.handler/ThingHandlerWithIncorrectBaseThingHandlerPackage.java
@@ -1,0 +1,23 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.openhab.test.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithIncorrectBaseThingHandlerPackage extends BaseThingHandler {
+
+    private String label;
+
+    public ThingHandlerWithIncorrectBaseThingHandlerPackage(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        setLabel("Label");
+    }
+
+    private void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithMultipleSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithMultipleSetLabel.java
@@ -1,0 +1,23 @@
+import java.net.Socket;
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithMultipleSetLabel extends BaseThingHandler {
+
+    public ThingHandlerWithMultipleSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        thing.setLabel("Label");
+    }
+
+    public void socketDidChangeLabel(Socket socket, String label) {
+        thing.setLabel(label);
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithSetLabelWithLiteralThis.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithSetLabelWithLiteralThis.java
@@ -1,0 +1,17 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithSetLabelWithLiteralThis extends BaseThingHandler {
+
+    public ThingHandlerWithSetLabelWithLiteralThis(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        this.thing.setLabel("Label");
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithThingFieldWithoutSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithThingFieldWithoutSetLabel.java
@@ -1,0 +1,24 @@
+import java.net.Socket;
+
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithThingFieldWithoutSetLabel extends BaseThingHandler {
+
+    public ThingHandlerWithThingFieldWithoutSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        // Empty - for the purpose of the test
+    }
+
+    public void socketDidInitialisation(Socket socket) {
+        thing.getStatus();
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithoutSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhab.binding.thing.handler/ThingHandlerWithoutSetLabel.java
@@ -1,0 +1,17 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithoutSetLabel extends BaseThingHandler {
+
+    public ThingHandlerWithoutSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        // Empty - for the purpose of the test
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhabl.binding.thing.field/ThingHandlerWithoutThingFieldWithSetLabel.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/thingHandlerSetLabelCheckTest/org.openhabl.binding.thing.field/ThingHandlerWithoutThingFieldWithSetLabel.java
@@ -1,0 +1,23 @@
+import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+
+public class ThingHandlerWithoutThingFieldWithSetLabel extends BaseThingHandler {
+
+    private String label;
+
+    public ThingHandlerWithoutThingFieldWithSetLabel(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(@NonNull ChannelUID channelUID, Command command) {
+        setLabel("Label");
+    }
+
+    private void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -146,6 +146,10 @@
     <property name="featureXmlPath" value="${checkstyle.karafFeatureCheck.featureXmlPath}" default="features/openhab-addons/src/main/feature/feature.xml" />
   </module>
 
+  <module name="org.openhab.tools.analysis.checkstyle.ThingHandlerSetLabelCheck">
+    <property name="severity" value="warning" />
+  </module>
+
   <module name="TreeWalker">
     <!-- See http://checkstyle.sourceforge.net/config_coding.html#IllegalThrows -->
     <module name="IllegalThrows">


### PR DESCRIPTION
Add new check to generate a warning if a class that extends BaseThingHandler tries to set the Thing label.
Fixed #198  