### PR TITLE
Add detector for wrong classname in logger

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/findbugs/visitors.xml
+++ b/sat-plugin/src/main/resources/rulesets/findbugs/visitors.xml
@@ -37,6 +37,7 @@
   <visitor>InfiniteRecursiveLoop</visitor>
   <visitor>InitializationChain</visitor>
   <visitor>InitializeNonnullFieldsInConstructor</visitor>
+  <visitor>IllegalPassedClassDetector</visitor>
   <visitor>InvalidJUnitTest</visitor>
   <visitor>ManualMessageDetector</visitor>
   <visitor>MutableLock</visitor>


### PR DESCRIPTION
See https://github.com/openhab/static-code-analysis/issues/213

NOTE : The severity of this check is ERROR, so the code base should be cleaned.

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>