### PR TITLE
Added check to look for proper contribution description of javadoc authors

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
@@ -1,0 +1,230 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.TextBlock;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Checks if there is proper contribution description of the first javadoc author and
+ * random(just not empty) contribution description of every other javadoc author in
+ * class/interface/enumeration and generates a warning if they are missing
+ *
+ * @author Kristina Simova - Initial contribution
+ *
+ */
+public class AuthorContributionDescriptionCheck extends AbstractCheck {
+
+    /**
+     * Indicates whether the inner classes/interfaces/enumerations (briefly
+     * called units) should be checked for an author tag. It is a configuration
+     * property and can be changed through the check's configuration.
+     */
+    private boolean checkInnerUnits;
+
+    private static final String AUTHOR_TAG = "@author";
+    private static final String WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION = "Javadoc author should not have empty contribution description.";
+    private static final String WARNING_MESSAGE_PREFIX = "First javadoc author should have \"";
+    private static final String WARNING_MESSAGE_SUFFIX = "\" contribution description.";
+    private static final String WARNING_MESSAGE_DELIMITER = "\", \"";
+
+    /**
+     * A list of contribution descriptions of the first javadoc author. It is a
+     * configuration property and can be changed through the check's configuration.
+     */
+    private List<String> requiredContributionDescriptions;
+
+    private String warningMessageFirstAuthorDescription;
+
+    /**
+     * We split a commentLine with an author tag by space(" "). Minimum possible length of the array
+     * is 4 as we have: "*", "@author", "AUTHOR_FIRST_NAME", "AUTHOR_LAST_NAME". If length is
+     * less than 4 or 4 then the javadoc author has no contribution description.
+     */
+    private static final int MIN_TOKENS_BY_WHITESPACE = 4;
+
+    /**
+     * We split a commentLine with an author tag by " - ". We get at least 2 Strings as we have "* @author
+     * AUTHOR_FIRST_NAME AUTHOR_LAST_NAME" as first String and "any contribution description" as second String. if
+     * length is less than 2 then the javadoc author has no contribution description.
+     */
+    private static final int MIN_TOKENS_BY_DASH = 2;
+
+    /**
+     * After splitting a commentLine with an author tag by " - " the position of the contribution
+     * description is 1.
+     */
+    private static final int CONTRIBUTION_DESCRIPTION_POSITION = 1;
+
+    public void setCheckInnerUnits(boolean checkInnerUnits) {
+        this.checkInnerUnits = checkInnerUnits;
+    }
+
+    public void setRequiredContributionDescriptions(String[] contributionDescriptions) {
+        this.requiredContributionDescriptions = new ArrayList<String>(Arrays.asList(contributionDescriptions));
+        setWarningMessageFirstAuthorDescription(requiredContributionDescriptions);
+    }
+
+    /**
+     * A method that sets the warning message if proper author contribution description
+     * of the first javadoc author is missing. As we get the required contribution
+     * descriptions of the first javadoc author from the check's configuration, we
+     * have to set the warning message with given below prefix, suffix and proper
+     * delimiter
+     *
+     * @param contributionDescriptions the list with possible
+     *            contribution descriptions of the first javadoc author
+     */
+    private void setWarningMessageFirstAuthorDescription(List<String> contributionDescriptions) {
+        warningMessageFirstAuthorDescription = contributionDescriptions.stream().map(Object::toString)
+                .collect(Collectors.joining(WARNING_MESSAGE_DELIMITER, WARNING_MESSAGE_PREFIX, WARNING_MESSAGE_SUFFIX))
+                .toString();
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        if (!checkInnerUnits) {
+            DetailAST astParent = ast.getParent();
+            if (astParent == null) {
+                visit(ast);
+            }
+        } else {
+            visit(ast);
+        }
+    }
+
+    public void visit(DetailAST ast) {
+        FileContents contents = getFileContents();
+        int typeDefinitionLineNumber = ast.getLineNo();
+        TextBlock textBlock = contents.getJavadocBefore(typeDefinitionLineNumber);
+        if (textBlock != null) {
+            checkIfAuthorTagHasDescription(typeDefinitionLineNumber, textBlock.getText());
+        } else {
+            // it should be handled by AuthorTagCheck
+        }
+    }
+
+    /**
+     * Checks if an author tag has contribution description
+     *
+     * @param typeDefinitionLineNumber the line number where type definition starts
+     * @param javadocComment the JavaDoc comment for the type definition.
+     */
+    private void checkIfAuthorTagHasDescription(int typeDefinitionLineNumber, String... javadocComment) {
+        int authorTagCount = 0;
+        for (int javadocLineIndex = 0; javadocLineIndex < javadocComment.length; javadocLineIndex++) {
+            String commentLine = javadocComment[javadocLineIndex];
+            if (commentLine.contains(AUTHOR_TAG)) {
+                int authorTagLineNumber = typeDefinitionLineNumber - javadocComment.length + javadocLineIndex;
+                authorTagCount += 1;
+                // check first author contribution message
+                if (authorTagCount == 1) {
+                    checkAuthorContributionDescription(authorTagLineNumber, commentLine, true,
+                            warningMessageFirstAuthorDescription);
+                } else {
+                    checkAuthorContributionDescription(authorTagLineNumber, commentLine, false,
+                            WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+                }
+            }
+        }
+    }
+
+    /**
+     * Checks for contribution description of javadoc author
+     *
+     * @param authorTagLineNumber the line number where the author tag is located
+     * @param commentLine the whole line of comment in which the author tag is located
+     * @param isFirstAuthor indicates whether this is the first author of the current javadoc comment so that it can
+     *            generate a proper warning message
+     * @param warningMessage the warning message based on whether we call this method
+     *            on the first author or on any other author of the current javadoc comment
+     */
+    private void checkAuthorContributionDescription(int authorTagLineNumber, String commentLine, boolean isFirstAuthor,
+            String warningMessage) {
+        String[] wordsInLine = commentLine.split(" ");
+        if (wordsInLine.length < MIN_TOKENS_BY_WHITESPACE || !(commentLine.contains(" - "))) {
+            log(authorTagLineNumber, warningMessage);
+        } else {
+            String[] linePartsByDash = commentLine.split(" - ");
+            if (isFirstAuthor) {
+                checkFirstAuthorContributionDescription(linePartsByDash, authorTagLineNumber, warningMessage);
+            } else {
+                checkOtherAuthorContributionDescription(linePartsByDash, authorTagLineNumber, warningMessage);
+            }
+        }
+    }
+
+    /**
+     * Checks if the first author of the current javadoc comment has proper contribution
+     * description
+     *
+     * @param linePartsByDash array of String that we get after splitting by " - "
+     * @param authorTagLineNumber the line number where the author tag is located
+     * @param warningMessage the warning message to generate if proper contribution
+     *            description of the first author of the current javadoc comment is missing
+     */
+    private void checkFirstAuthorContributionDescription(String[] linePartsByDash, int authorTagLineNumber,
+            String warningMessage) {
+        String firstAuthorDescription = linePartsByDash[CONTRIBUTION_DESCRIPTION_POSITION].trim();
+        boolean isDescriptionValid = false;
+        for (String contributionDescription : requiredContributionDescriptions) {
+            if (StringUtils.containsIgnoreCase(firstAuthorDescription, contributionDescription)) {
+                isDescriptionValid = true;
+                break;
+            }
+        }
+        if (!isDescriptionValid) {
+            log(authorTagLineNumber, warningMessage);
+        }
+    }
+
+    /**
+     * Checks if any other author of the current javadoc comment has empty contribution
+     * description
+     *
+     * @param linePartsByDash array of String that we get after splitting by " - "
+     * @param authorTagLineNumber the line number where the author tag is located
+     * @param warningMessage the warning message to generate if the contribution
+     *            description of any other author of the current javadoc comment is empty
+     */
+    private void checkOtherAuthorContributionDescription(String[] linePartsByDash, int authorTagLineNumber,
+            String warningMessage) {
+        if (linePartsByDash.length < MIN_TOKENS_BY_DASH
+                || linePartsByDash[CONTRIBUTION_DESCRIPTION_POSITION].trim().isEmpty()) {
+            log(authorTagLineNumber, warningMessage);
+        }
+    }
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] { TokenTypes.INTERFACE_DEF, TokenTypes.CLASS_DEF, TokenTypes.ENUM_DEF };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtils.EMPTY_INT_ARRAY;
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.AuthorContributionDescriptionCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link AuthorContributionDescriptionCheck}
+ *
+ * @author Kristina Simova - Initial contribution
+ *
+ */
+public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckTest {
+
+    private static final String EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION = "First javadoc author should have \"Initial contribution\", \"Initial contribution and API\" contribution description.";
+    private static final String EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION = "Javadoc author should not have empty contribution description.";
+    private static final String TEST_DIRECTORY_NAME = "authorContributionDescriptionCheckTest";
+
+    /**
+     * The needed attributes for the configuration. They should be the same as their
+     * corresponding properties defined in rulesets.checkstyle/rules.xml file
+     */
+    private static final String ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME = "requiredContributionDescriptions";
+    private static final String ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE = "Initial contribution,Initial contribution and API";
+    private static final String ATTRIBUTE_CHECK_UNITS_NAME = "checkInnerUnits";
+
+    private Map<Integer, String> lineNumberToWarningMessageExpected;
+
+    private DefaultConfiguration configuration;
+
+    @Before
+    public void setUp() {
+        lineNumberToWarningMessageExpected = new TreeMap<>();
+        configuration = createCheckConfig(AuthorContributionDescriptionCheck.class);
+        configuration.addAttribute(ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME, ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE);
+    }
+
+    /*
+     * outer class has no first author contribution description
+     */
+    @Test
+    public void testOuterClassWithNoFirstAuthorContributionDescription() throws Exception {
+        String fileName = "NoFirstAuthorContributionDescriptions.java";
+        /*
+         * a warning message is expected at the line where the first author of the outer class is
+         * located, because first author contribution description is missing there
+         */
+        int warningLine = 2;
+        lineNumberToWarningMessageExpected.put(warningLine, EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = false;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer class has no other author contribution description
+     */
+    @Test
+    public void testOuterClassWithNoOtherAuthorContributionDescription() throws Exception {
+        String fileName = "NoOtherAuthorContributionDescriptions.java";
+        /*
+         * a warning message is expected at the line where the other author of the outer class is
+         * located, because other author contribution description is missing there
+         */
+        int warningLine = 3;
+        lineNumberToWarningMessageExpected.put(warningLine, EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = false;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * inner class has no first author contribution description
+     */
+    @Test
+    public void testInnerClassWithNoFirstAuthorContributionDescription() throws Exception {
+        String fileName = "NoFirstAuthorContributionDescriptionInnerClass.java";
+        /*
+         * a warning message is expected at the line where the first author of the inner class is
+         * located, because first author contribution description is missing there
+         */
+        int warningLine = 9;
+        lineNumberToWarningMessageExpected.put(warningLine, EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * inner class has no other author contribution description
+     */
+    @Test
+    public void testInnerClassWithNoOtherAuthorContributionDescription() throws Exception {
+        String fileName = "NoOtherAuthorContributionDescriptionInnerClass.java";
+        /*
+         * a warning message is expected at the line where the other author of the inner class is
+         * located, because other author contribution description is missing there
+         */
+        int warningLine = 10;
+        lineNumberToWarningMessageExpected.put(warningLine, EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer and inner classes with no first author contribution description
+     */
+    @Test
+    public void testOuterAndInnerClassesWithNoFirstAuthorContributionDescription() throws Exception {
+        String fileName = "NoFirstAuthorContributionDescriptions.java";
+        /*
+         * warning messages are expected at the lines where first authors of outer and inner
+         * classes are located, because first author contribution descriptions are missing there
+         */
+        int firstWarningLineFirstAuthor = 2;
+        int secondWarningLineFirstAuthor = 9;
+        lineNumberToWarningMessageExpected.put(firstWarningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(secondWarningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer and inner classes with no other author contribution description
+     */
+    @Test
+    public void testOuterAndInnerClassesWithNoOtherAuthorContributionDescription() throws Exception {
+        String fileName = "NoOtherAuthorContributionDescriptions.java";
+        /*
+         * warning messages are expected at the lines where other authors of outer and inner
+         * classes are located, because other author contribution descriptions are missing there
+         */
+        int firstWarningLineOthertAuthor = 3;
+        int secondWarningLineOtherAuthor = 10;
+        lineNumberToWarningMessageExpected.put(firstWarningLineOthertAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(secondWarningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer class with no first author contribution description and
+     * inner class with no other author contribution description
+     */
+    @Test
+    public void testOuterClassWithNoFirstAuthorContributionDescriptionAndInnerClassWithNoOtherAuthorContributionDescription()
+            throws Exception {
+        String fileName = "NoContributionDescriptionFirstAuthorOtherAuthor.java";
+        /*
+         * warning messages are expected at the lines where the first author of the outer class and other
+         * author of the inner class are located, because author contribution descriptions are missing there
+         */
+        int warningLineFirstAuthor = 2;
+        int warningLineOtherAuthor = 10;
+        lineNumberToWarningMessageExpected.put(warningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(warningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer class with no other author contribution description and
+     * inner class with no first author contribution description
+     */
+    @Test
+    public void testOuterClassWithNoOtherAuthorContributionDescriptionAndInnerClassWithNoFirstAuthorContributionDescription()
+            throws Exception {
+        String fileName = "NoContributionDescriptionOtherAuthorFirstAuthor.java";
+        /*
+         * warning messages are expected at the lines where the other author of the outer class and first
+         * author of the inner class are located, because author contribution descriptions are missing there
+         */
+        int warningLineFirstAuthor = 9;
+        int warningLineOtherAuthor = 3;
+        lineNumberToWarningMessageExpected.put(warningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(warningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer class with wrong first author contribution description
+     */
+    @Test
+    public void testOuterClassWithWrongFirstAuthorContributionDescription() throws Exception {
+        String fileName = "WrongFirstAuthorContributionDescription.java";
+        /*
+         * warning message is expected at the line where the first author of outer class
+         * is located, because author contribution description is wrong
+         */
+        int warningLineFirstAuthor = 2;
+        lineNumberToWarningMessageExpected.put(warningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = false;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer class with wrong other author contribution description - empty
+     */
+    @Test
+    public void testOuterClassWithWrongOtherAuthorContributionDescription() throws Exception {
+        String fileName = "WrongOtherAuthorContributionDescription.java";
+        /*
+         * warning message is expected at the line where the other author of outer class
+         * is located, because author contribution description is wrong
+         */
+        int warningLineOtherAuthor = 3;
+        lineNumberToWarningMessageExpected.put(warningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = false;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer and inner classes with no author contribution descriptions
+     */
+    @Test
+    public void testOuterAndInnerClassesWithNoAuthorContributionDescriptions() throws Exception {
+        String fileName = "NoContributionDescriptions.java";
+        /*
+         * warning messages are expected at the lines where all the authors of outer and inner classes
+         * are located, because author contribution descriptions are missing there
+         */
+        int firstWarningLineFirstAuthor = 2;
+        int secondWarningLineFirstAuthor = 9;
+        int firstWarningLineOtherAuthor = 3;
+        int secondWarningLineOtherAuthor = 10;
+        lineNumberToWarningMessageExpected.put(firstWarningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(secondWarningLineFirstAuthor,
+                EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(firstWarningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        lineNumberToWarningMessageExpected.put(secondWarningLineOtherAuthor,
+                EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION);
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    /*
+     * outer and inner classes with all author contribution descriptions
+     */
+    @Test
+    public void testOuterAndInnerClassesWithAuthorContributionDescriptions() throws Exception {
+        String fileName = "PresentContributionDescriptions.java";
+        /*
+         * no warnings are expected so we pass an empty map
+         */
+        boolean checkInnerClasses = true;
+        checkFileForAuthorContributionDescription(checkInnerClasses, fileName);
+    }
+
+    private void checkFileForAuthorContributionDescription(boolean checkInnerUnits, String fileName) throws Exception {
+        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String[] expected = null;
+
+        if (lineNumberToWarningMessageExpected.isEmpty()) {
+            expected = CommonUtils.EMPTY_STRING_ARRAY;
+        } else {
+            expected = lineNumberToWarningMessageExpected.entrySet().stream()
+                    .map(entry -> entry.getKey() + ": " + entry.getValue())
+                    .toArray(size -> new String[lineNumberToWarningMessageExpected.size()]);
+        }
+
+        configuration.addAttribute(ATTRIBUTE_CHECK_UNITS_NAME, String.valueOf(checkInnerUnits));
+        verify(configuration, filePath, expected);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptionFirstAuthorOtherAuthor.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptionFirstAuthorOtherAuthor.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco
+ * @author María de los Remedios - Random contribution description
+ *
+ */
+public class NoContributionDescriptionFirstAuthorOtherAuthor {
+
+    /**
+     * @author Cipriano de la Santísima - Initial contribution
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso                        
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptionOtherAuthorFirstAuthor.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptionOtherAuthorFirstAuthor.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios 
+ *
+ */
+public class NoContributionDescriptionOtherAuthorFirstAuthor {
+
+    /**
+     * @author Cipriano de la Santísima 
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso - Changed some methods
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptions.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoContributionDescriptions.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco
+ * @author María de los Remedios
+ *
+ */
+public class NoContributionDescriptions {
+
+    /**
+     * @author Cipriano de la Santísima
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoFirstAuthorContributionDescriptionInnerClass.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoFirstAuthorContributionDescriptionInnerClass.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios - Added some tests
+ *
+ */
+public class NoFirstAuthorContributionDescriptionInnerClass {
+
+    /**
+     * @author Cipriano de la Santísima
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso - Changed some methods
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoFirstAuthorContributionDescriptions.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoFirstAuthorContributionDescriptions.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco 
+ * @author María de los Remedios - Added some tests
+ *
+ */
+public class NoFirstAuthorContributionDescriptions {
+
+    /**
+     * @author Cipriano de la Santísima
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso - Changed some methods
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoOtherAuthorContributionDescriptionInnerClass.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoOtherAuthorContributionDescriptionInnerClass.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios - Changed some methods
+ *
+ */
+public class NoOtherAuthorContributionDescriptionInnerClass {
+
+    /**
+     * @author Cipriano de la Santísima - Initial contribution
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso 
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoOtherAuthorContributionDescriptions.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/NoOtherAuthorContributionDescriptions.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios 
+ *
+ */
+public class NoOtherAuthorContributionDescriptions {
+
+    /**
+     * @author Cipriano de la Santísima - Initial contribution
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso 
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/PresentContributionDescriptions.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/PresentContributionDescriptions.java
@@ -1,0 +1,16 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios - Added some tests
+ *
+ */
+public class PresentContributionDesciptions {
+
+    /**
+     * @author Cipriano de la Santísima - Initial contribution
+     * @author Anna-María Magdalena Trinidad Ruiz y Picasso - Changed some methods
+     * 
+     */
+    private class InnerClass {
+
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/WrongFirstAuthorContributionDescription.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/WrongFirstAuthorContributionDescription.java
@@ -1,0 +1,8 @@
+/**
+ * @author Pablo Diego José Francisco - Added some methods
+ * @author María de los Remedios - Added some tests
+ *
+ */
+public class WrongFirstAuthorContributionDescription {
+    
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/WrongOtherAuthorContributionDescription.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/authorContributionDescriptionCheckTest/WrongOtherAuthorContributionDescription.java
@@ -1,0 +1,8 @@
+/**
+ * @author Pablo Diego José Francisco - Initial contribution
+ * @author María de los Remedios -                              
+ *
+ */
+public class WrongOtherAuthorContributionDescription {
+        
+}

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -214,6 +214,12 @@
       <property name="severity" value="info"/>
       <property name="allowMissingPropertyJavadoc" value="true"/>
     </module>
+    
+    <module name="org.openhab.tools.analysis.checkstyle.AuthorContributionDescriptionCheck">
+       <property name="severity" value="warning"/>
+       <property name="requiredContributionDescriptions" value="initial contribution"/>
+       <property name="checkInnerUnits" value="false"/>
+    </module>
 
     <!-- Rules for Java Naming Convention -->
     


### PR DESCRIPTION
Checks if there is proper contribution description of the first javadoc author and random(just not empty) contribution description of every other javadoc author and generates a warning if they are missing.

Closes #199 

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>