### PR TITLE
Use http URL to download .xsd files.

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -123,7 +123,7 @@
     <property name="severity" value="error" />
     <property name="thingSchema" value="http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd" />
     <property name="bindingSchema" value="http://www.eclipse.org/smarthome/schemas/binding-1.0.0.xsd" />
-    <property name="configSchema" value="https://www.eclipse.org/smarthome/schemas/config-description-1.0.0.xsd" />
+    <property name="configSchema" value="http://www.eclipse.org/smarthome/schemas/config-description-1.0.0.xsd" />
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.EshInfXmlUsageCheck">


### PR DESCRIPTION
Https connection causes 'javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure'
because https://www.eclipse.org is using TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 cypher which is not provided by standard JDK 1.8 and requires Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files 8 to be locally installed in JAVA_HOME

Signed-off-by: Svilen Valkanov <svilen.valkanov@musala.com>