### PR TITLE
crete check to look for whitespace characters in xml indentation

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIdentationInXmlFilesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIdentationInXmlFilesCheck.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.XML_EXTENSION;
+
+import java.io.File;
+
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+
+import com.puppycrawl.tools.checkstyle.api.FileText;
+
+/**
+ * Checks whether whitespace characters are use instead of tabs in xml files 
+ * indentations and generates warnings in such cases.
+ * 
+ * @author Lyubomir Papazov - initial contribution
+ *
+ */
+public class OnlyTabIdentationInXmlFilesCheck extends AbstractStaticCheck {
+
+    private static final String PATTERN_TO_BE_FOLLOWED = "^\\t*[<].*";
+    private static final String WARNING_MESSAGE = "There were whitespace characters used for indentation. Please use tab characters instead";
+    private boolean onlyShowFirstWarning;
+    
+    
+    public OnlyTabIdentationInXmlFilesCheck() {
+        setFileExtensions(XML_EXTENSION);
+    }
+    
+    public void setOnlyShowFirstWarning(Boolean showFirstExceptionOnly)
+    {
+        this.onlyShowFirstWarning = showFirstExceptionOnly;
+    }
+    
+    @Override
+    protected void processFiltered(File file, FileText fileText) {
+        processXmlTabIdentationCheck(fileText);
+    }
+    
+    private void processXmlTabIdentationCheck(FileText fileText) {
+        for (int lineNumber = 0; lineNumber < fileText.size(); lineNumber++) {
+            String line = fileText.get(lineNumber);
+            if (!line.matches(PATTERN_TO_BE_FOLLOWED)) {
+                //log the 1-based index of the file
+                log(lineNumber + 1, WARNING_MESSAGE);
+                if (onlyShowFirstWarning) {
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIdentationInXmlFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIdentationInXmlFilesCheckTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2010-2017 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_STRING_ARRAY;
+
+import java.io.File;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.OnlyTabIdentationInXmlFilesCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import org.openhab.tools.analysis.checkstyle.api.CheckConstants;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;    
+
+
+/**
+ * Checks whether whitespace characters are use instead of tabs in xml files 
+ * indentations and generates warnings in such cases.
+ * 
+ * @author Lyubomir Papazov - initial contribution
+ */
+public class OnlyTabIdentationInXmlFilesCheckTest extends AbstractStaticCheckTest {
+    
+    private static final String WHITESPACE_USAGE_WARNING = "There were whitespace characters used for indentation. Please use tab characters instead";
+    private static final String TABIDENT_CHECK_TEST_DIRECTORY_NAME = "onlyTabIdentationInXmlFilesCheck";
+    private DefaultConfiguration config;
+    
+    @Before
+    public void setUpClass() {
+        config = createCheckConfig(OnlyTabIdentationInXmlFilesCheck.class);
+    }
+    
+    @Test
+    public void testOneLineXmlFile() throws Exception {
+        verifyXmlTabIdentation("WhiteSpacesNotUsedBeforeOpeningTags", noMessagesExpected());
+    }
+    
+    @Test
+    public void testOneIncorrectLine() throws Exception {
+        String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInOneLine", expectedMessages);
+    }
+    
+    @Test
+    public void testManyIncorrectLinesOnlyShowFirstWarning() throws Exception {
+        String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines", expectedMessages);
+    }
+    
+    @Test
+    public void testManyIncorrectLinesShowAllWarnings() throws Exception {
+        String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING, 6, WHITESPACE_USAGE_WARNING);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines", expectedMessages, false);
+    }
+    
+    private String[] noMessagesExpected() {
+        String[] expectedMessages = EMPTY_STRING_ARRAY;
+        return expectedMessages;
+    }
+    
+    private void verifyXmlTabIdentation(String fileName, String[] expectedMessages, boolean onlyShowFirstWarning) throws Exception {
+        String testFileRelativePath = TABIDENT_CHECK_TEST_DIRECTORY_NAME + File.separator + fileName + "." + CheckConstants.XML_EXTENSION;
+        String testFileAbsolutePath = getPath(testFileRelativePath);
+        String messageFilePath = testFileAbsolutePath;
+        if (onlyShowFirstWarning) {
+            config.addAttribute("onlyShowFirstWarning", "true");
+        } else {
+            config.addAttribute("onlyShowFirstWarning", "false");
+        }
+        verify(createChecker(config), testFileAbsolutePath, messageFilePath, expectedMessages);
+    }
+    
+    private void verifyXmlTabIdentation(String fileName, String[] expectedMessages) throws Exception {
+        verifyXmlTabIdentation(fileName, expectedMessages, true);
+    }
+    
+    @Override
+    protected DefaultConfiguration createCheckerConfig(Configuration config) {
+        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
+        defaultConfiguration.addChild(config);
+        return defaultConfiguration;
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpaceUsedBeforeOpeningTagInManyLines.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpaceUsedBeforeOpeningTagInManyLines.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugins>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>${maven.surefire.plugin.version}</version>
+</plugin>
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-eclipse-plugin</artifactId>
+	<version>${maven.eclipse.version}</version>
+	<configuration>
+		<downloadSources>true</downloadSources>
+		<downloadJavadocs>true</downloadJavadocs>
+	</configuration>
+</plugin>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpaceUsedBeforeOpeningTagInOneLine.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpaceUsedBeforeOpeningTagInOneLine.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugins>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+	<version>${maven.surefire.plugin.version}</version>
+</plugin>
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-eclipse-plugin</artifactId>
+	<version>${maven.eclipse.version}</version>
+	<configuration>
+		<downloadSources>true</downloadSources>
+		<downloadJavadocs>true</downloadJavadocs>
+	</configuration>
+</plugin>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpacesNotUsedBeforeOpeningTags.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIdentationInXmlFilesCheck/WhiteSpacesNotUsedBeforeOpeningTags.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?>

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -68,6 +68,11 @@
   <module name="org.openhab.tools.analysis.checkstyle.OverridingParentPomConfigurationCheck">
     <property name="severity" value="warning" />
   </module>
+  
+  <module name="org.openhab.tools.analysis.checkstyle.OnlyTabIdentationInXmlFilesCheck">
+    <property name="severity" value="warning" />
+    <property name="onlyShowFirstWarning" value="true" />
+  </module>
 
   <module name="org.openhab.tools.analysis.checkstyle.RequireBundleCheck">
       <property name="severity" value="error" />


### PR DESCRIPTION
Create a check that verifies that XML files use tabs instead of spaces as suggested [here](https://github.com/openhab/static-code-analysis/issues/223)