### PR TITLE
Added check to look for missing optional Import-Package dependency to org.eclipse.jdt.annotation in a bundle

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AnnotationDependencyCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AnnotationDependencyCheck.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.MANIFEST_EXTENSION;
+
+import java.io.File;
+import java.util.Set;
+
+import org.apache.ivy.osgi.core.BundleInfo;
+import org.apache.ivy.osgi.core.BundleRequirement;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
+
+import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+
+/**
+ * Checks if every bundle has optional Import-Package dependency to org.eclipse.jdt.annotation and generates a <b>
+ * WARNING </b> if it is missing.
+ *
+ * @author Kristina Simova - Initial contribution
+ *
+ */
+public class AnnotationDependencyCheck extends AbstractStaticCheck {
+    private static final String DEPENDENCY_NAME = "org.eclipse.jdt.annotation";
+    private static final String DEPENDENCY_RESOLUTION = "optional";
+    private static final String IMPORT_PACKAGE_HEADER_NAME = "Import-Package";
+    private static final String WARNING_MESSAGE_MISSING_DEPENDENCY_RESOLUTION = "Every bundle should have optional Import-Package dependency to org.eclipse.jdt.annotation.";
+
+    public AnnotationDependencyCheck() {
+        setFileExtensions(MANIFEST_EXTENSION);
+    }
+
+    @Override
+    protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
+        if (isEmpty(fileText)) {
+            // it should be handled by another check
+            return;
+        }
+        BundleInfo bundleInfo = parseManifestFromFile(fileText);
+        Set<BundleRequirement> bundleRequirements = bundleInfo.getRequirements();
+        int lineNo = findLineNumberSafe(fileText, IMPORT_PACKAGE_HEADER_NAME, 0,
+                "Could not find Import-Package dependency!");
+        if (lineNo == 0) {
+            // it means that the MANIFEST.MF file has no Import-Package dependency
+            return;
+        }
+        boolean hasOptionalDependencyResolution = false;
+        for (BundleRequirement requirement : bundleRequirements) {
+            String dependencyName = requirement.getName();
+            String dependencyResolution = requirement.getResolution();
+            if (DEPENDENCY_NAME.equals(dependencyName) && DEPENDENCY_RESOLUTION.equals(dependencyResolution)) {
+                hasOptionalDependencyResolution = true;
+                break;
+            }
+        }
+        if (!hasOptionalDependencyResolution) {
+            log(lineNo, WARNING_MESSAGE_MISSING_DEPENDENCY_RESOLUTION);
+        }
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.AnnotationDependencyCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link AnnotationDependencyCheck}
+ *
+ * @author Kristina Simova - Initial contribution
+ *
+ */
+public class AnnotationDependencyCheckTest extends AbstractStaticCheckTest {
+
+    private static final String TEST_DIRECTORY_NAME = "annotationDependencyCheckTest";
+    private static final String EXPECTED_WARNING_MESSAGE = "Every bundle should have optional Import-Package dependency to org.eclipse.jdt.annotation.";
+    private static DefaultConfiguration checkConfiguration = createCheckConfig(AnnotationDependencyCheck.class);
+
+    @Override
+    protected DefaultConfiguration createCheckerConfig(Configuration configuration) {
+        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
+        defaultConfiguration.addChild(configuration);
+        return defaultConfiguration;
+    }
+
+    @Test
+    public void testManifestFileWithoutOptionalAnnotationDependency() throws Exception {
+        String fileName = "MANIFEST.MF";
+        String[] expectedMessage = generateExpectedMessages(9, EXPECTED_WARNING_MESSAGE);
+        checkFile(fileName, expectedMessage);
+    }
+
+    @Test
+    public void testManifestFileWithOptionalAnnotationDependency() throws Exception {
+        String fileName = "MANIFEST2.MF";
+        checkFile(fileName, CommonUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testManifestFileWithImportPackageDependencyAndMissingOptionalResolution() throws Exception {
+        String fileName = "MANIFEST3.MF";
+        String[] expectedMessage = generateExpectedMessages(9, EXPECTED_WARNING_MESSAGE);
+        checkFile(fileName, expectedMessage);
+    }
+
+    private void checkFile(String fileName, String... expectedMessages) throws Exception {
+        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        verify(checkConfiguration, filePath, expectedMessages);
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST.MF
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST.MF
@@ -1,0 +1,12 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST2.MF
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST2.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j,
+ org.eclipse.jdt.annotation;resolution:=optional

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST3.MF
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/annotationDependencyCheckTest/MANIFEST3.MF
@@ -1,0 +1,13 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Astro Binding
+Bundle-SymbolicName: org.openhab.binding.astro;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.1.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.apache.commons.lang,
+ org.quartz.utils,
+ org.slf4j
+ org.eclipse.jdt.annotation

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -150,6 +150,10 @@
     <property name="severity" value="${checkstyle.karafFeatureCheck.severity}" default="ignore" />
     <property name="featureXmlPath" value="${checkstyle.karafFeatureCheck.featureXmlPath}" default="features/openhab-addons/src/main/feature/feature.xml" />
   </module>
+  
+  <module name="org.openhab.tools.analysis.checkstyle.AnnotationDependencyCheck">
+    <property name="severity" value="warning" />
+  </module>
 
   <module name="TreeWalker">
     <!-- See http://checkstyle.sourceforge.net/config_coding.html#IllegalThrows -->


### PR DESCRIPTION
Added check to generate WARNING if a bundle does not have optional Import-Package dependency to org.eclipse.jdt.annotation
See #218 

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>