### PR TITLE
Modified MethodNameCheck's regular expression to match custom OSGi (Equinox) console commands

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -28,7 +28,7 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckTest {
 
-    private static final String EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION = "First javadoc author should have \"Initial contribution\", \"Initial contribution and API\" contribution description.";
+    private static final String EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION = "First javadoc author should have \"Initial contribution\" contribution description.";
     private static final String EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION = "Javadoc author should not have empty contribution description.";
     private static final String TEST_DIRECTORY_NAME = "authorContributionDescriptionCheckTest";
 
@@ -37,7 +37,7 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
      * corresponding properties defined in rulesets.checkstyle/rules.xml file
      */
     private static final String ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME = "requiredContributionDescriptions";
-    private static final String ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE = "Initial contribution,Initial contribution and API";
+    private static final String ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE = "Initial contribution";
     private static final String ATTRIBUTE_CHECK_UNITS_NAME = "checkInnerUnits";
 
     private Map<Integer, String> lineNumberToWarningMessageExpected;

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -217,7 +217,7 @@
     
     <module name="org.openhab.tools.analysis.checkstyle.AuthorContributionDescriptionCheck">
        <property name="severity" value="warning"/>
-       <property name="requiredContributionDescriptions" value="initial contribution"/>
+       <property name="requiredContributionDescriptions" value="Initial contribution"/>
        <property name="checkInnerUnits" value="false"/>
     </module>
 
@@ -234,6 +234,8 @@
       <property name="severity" value="info" />
     </module>
     <module name="MethodName">
+        <property name="format"
+            value="^\_?[a-z][a-zA-Z0-9]*$"/>
       <property name="severity" value="info" />
     </module>
     <module name="ConstantName">


### PR DESCRIPTION
Modified MethodNameCheck's regular expression to match methods which begin with underscore (custom OSGi console commands) and fixed AuthorContributionDescriptionCheckTest's warning message.

Signed-off-by: Kristina S. Simova <kssimovaa@gmail.com>