### PR TITLE
Changed the severity from warning to error for OnlyTabIdentationInXmlFilesCheck

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -76,7 +76,7 @@
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.OnlyTabIndentationInXmlFilesCheck">
-    <property name="severity" value="warning" />
+    <property name="severity" value="error" />
     <property name="onlyShowFirstWarning" value="true" />
   </module>
 

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
@@ -24,4 +24,5 @@
     <!--  Allow the usage of scheduleAtFixedRate in FadingWiFiLEDDriver class  -->
     <suppress files=".+org.openhab.binding.wifiled.handler.FadingWiFiLEDDriver.java" checks="AvoidScheduleAtFixedRateCheck"/>
     <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
+    <suppress files=".+[\\/]OSGI-INF[\\/]org.openhab.+\.xml" checks="OnlyTabIndentationInXmlFilesCheck|NewlineAtEndOfFileCheck"/>
 </suppressions>


### PR DESCRIPTION
@kaikreuzer @maggu2810 As we talked, after fixing all XML files found by the Static Code Analysis Tool for the OnlyTabIdentationInXmlFilesCheck I changed the severity of the check from warning to error.