### PR TITLE
Set suppression for all pom.xml files for OnlyTabIndentationInXmlFilesCheck

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
@@ -23,4 +23,5 @@
     <suppress files=".+org.openhab.voice.voicerss.+" checks="PackageExportsNameCheck"/>
     <!--  Allow the usage of scheduleAtFixedRate in FadingWiFiLEDDriver class  -->
     <suppress files=".+org.openhab.binding.wifiled.handler.FadingWiFiLEDDriver.java" checks="AvoidScheduleAtFixedRateCheck"/>
+	<suppress files=".+\\pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
 </suppressions>


### PR DESCRIPTION
@kaikreuzer I set suppression for the pom.xml files for this check, so they can be excluded in openHAB repos also, as you proposed to do for smarthome.