### PR TITLE
Add parameter "includes" in pmd.properties file

### DIFF
--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -78,6 +78,7 @@ public class PmdChecker extends AbstractChecker {
         // so they have to be set direct in the configuration
         Xpp3Dom configuration = configuration(
                 element("targetDirectory", userProps.getProperty("pmd.custom.targetDirectory")),
+                element("includes", userProps.getProperty("pmd.custom.includes")),
                 element("rulesets", element("ruleset", rulesetLocation)));
 
         pmdPlugins.add(dependency("org.openhab.tools.sat.custom-checks", "pmd", plugin.getVersion()));

--- a/sat-plugin/src/main/resources/configuration/pmd.properties
+++ b/sat-plugin/src/main/resources/configuration/pmd.properties
@@ -1,3 +1,4 @@
 pmd.custom.targetDirectory=target/code-analysis
+pmd.custom.includes=src/main/java/**
 linkXRef=false
 outputEncoding=UTF-8


### PR DESCRIPTION
After fixing one of the issues found by Static Code Analysis Tool on smarthome repository for  BuildPropertiesCheck, by adding src/main/java/ and src/test/java/ directories to "source" property in build.properties file in /smarthome/bundles/test/org.eclipse.smarthome.test, I got an error from PMD for one of the test files - "org.eclipse.smarthome.test.java.JavaTestTest.java".

The test file is written by @htreu and the error is for "throwing null pointer exception", so I added parameter "includes" in pmd.properties, so only files in src/main/java/ will be checked.

@kaikreuzer @martinvw What do you think? Should we exclude the test files for PMD?