### PR TITLE
remove obsolete (plugin)repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,33 +199,4 @@
     <module>sat-plugin</module>
   </modules>
   
-  <pluginRepositories>
-    <pluginRepository>
-      <id>artifactory</id>
-      <name>JFrog Artifactory Repository</name>
-      <url>https://openhab.jfrog.io/openhab/libs-release</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-  
-  <repositories>
-    <repository>
-      <id>openhab-artifactory-release</id>
-      <name>JFrog Artifactory Repository</name>
-      <url>https://openhab.jfrog.io/openhab/libs-release</url>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-        </snapshots>
-    </repository>
-  </repositories>
 </project>


### PR DESCRIPTION
After I played around with the SAT plugin in some example projects, I
realized that artifacts are requested by JCenter without having the
repository enabled in the artifacts itself.
I don't think it is good to use a plugin that injects additional
repositories into the build.
After removing the repositories and plugin respitories in the parent POM
of SAT, I tried to build it using an empty local Maven repo. It
succeeded, so IMHO that third party repositories are not necessary
anymore.