### PR TITLE
Fix OnlyTabIndentationInXmlFilesCheck in pom.xml also with Unix paths

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
@@ -23,5 +23,5 @@
     <suppress files=".+org.openhab.voice.voicerss.+" checks="PackageExportsNameCheck"/>
     <!--  Allow the usage of scheduleAtFixedRate in FadingWiFiLEDDriver class  -->
     <suppress files=".+org.openhab.binding.wifiled.handler.FadingWiFiLEDDriver.java" checks="AvoidScheduleAtFixedRateCheck"/>
-	<suppress files=".+\\pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
+    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
 </suppressions>


### PR DESCRIPTION
@tanyatanyatanya https://github.com/openhab/static-code-analysis/pull/271 suppressed OnlyTabIndentationInXmlFilesCheck in POM files only with Windows paths.