### PR TITLE
update checkstyle version to 8.9

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
@@ -9,10 +9,9 @@
 package org.openhab.tools.analysis.checkstyle.api;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 
-import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
+import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
 
 /**
  * Base test class for static code analysis checks
@@ -20,23 +19,11 @@ import com.puppycrawl.tools.checkstyle.BaseCheckTestSupport;
  * @author Svilen Valkanov - Initial contribution
  * @author Petar Valchev - Implement method to get the path in the expected format from checkstyle
  */
-public abstract class AbstractStaticCheckTest extends BaseCheckTestSupport {
-
-    /**
-     * Resolves absolute path to a resource
-     *
-     * @param relativePathToFile - relative path to src/test/resources/checks/checkstyle . It should
-     *            be "/" separated path.
-     * @return absolute path or null if the string can not be parsed as URI
-     */
-    @Override
-    protected String getPath(String relativePathToFile) throws IOException {
-        return new File("src/test/resources/checkstyle/" + relativePathToFile).getCanonicalPath();
-    }
+public abstract class AbstractStaticCheckTest extends AbstractModuleTestSupport {
 
     /**
      * Generates message that can be used in the
-     * {@link BaseCheckTestSupport} verify methods.
+     * {@link AbstractModuleTestSupport} verify methods.
      *
      * @param arguments - a set of line number and message pairs
      * @return String[] in the format used from checkstyle to verify the logged messages

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AboutHtmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AboutHtmlCheckTest.java
@@ -22,7 +22,6 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 import org.openhab.tools.analysis.utils.CachingHttpClient;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -32,8 +31,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Svilen Valkanov - Added test for about.html file missing in build.properties
  */
 public class AboutHtmlCheckTest extends AbstractStaticCheckTest {
-    private static final String ABOUT_HTML_CHECK_TEST_DIRECTORY_NAME = "aboutHtmlCheckTest";
-
     private static final String VALID_ABOUT_HTML_FILE_URL = "https://raw.githubusercontent.com/openhab/openhab2-addons/master/src/etc/about.html";
 
     private static final String VALID_ABOUT_HTML_FILE_LINK_MSG = "Here is an example of a valid about.html file: "
@@ -48,6 +45,11 @@ public class AboutHtmlCheckTest extends AbstractStaticCheckTest {
     private DefaultConfiguration config;
 
     private boolean availableResourceURL = false;
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/aboutHtmlCheckTest";
+    }
 
     @Before
     public void setUp() {
@@ -140,7 +142,7 @@ public class AboutHtmlCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void testMissingValidAboutHtmlFile() throws Exception {
-        config = createCheckConfig(AboutHtmlCheck.class);
+        config = createModuleConfig(AboutHtmlCheck.class);
         config.addAttribute("validAboutHtmlFileURL", "non.existent.url");
 
         String[] expectedMessages = CommonUtils.EMPTY_STRING_ARRAY;
@@ -154,35 +156,22 @@ public class AboutHtmlCheckTest extends AbstractStaticCheckTest {
 
         String[] expectedMessages = generateExpectedMessages(0, MISSING_ABOUT_HTML_IN_BUILD_PROPERTIES_MSG);
         String testDirectoryName = "about_html_missing_in_build_properties";
+        File testDirectory = new File(getPath(testDirectoryName));
 
         // The message is logged for the build.properties file
-        String testDirectoryRelativePath = ABOUT_HTML_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName;
-        String testDirectoryAbsolutePath = getPath(testDirectoryRelativePath);
-        File testDirectory = new File(testDirectoryAbsolutePath);
-
-        String messageFilePath = testDirectoryAbsolutePath + File.separator + "build.properties";
+        String messageFilePath = getPath(testDirectoryName) + File.separator + "build.properties";
 
         verify(createChecker(config), testDirectory.listFiles(), messageFilePath, expectedMessages);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
-    }
-
     private void createValidConfig() throws IOException {
-        config = createCheckConfig(AboutHtmlCheck.class);
+        config = createModuleConfig(AboutHtmlCheck.class);
         config.addAttribute("validAboutHtmlFileURL", VALID_ABOUT_HTML_FILE_URL);
     }
 
     private void verifyAboutHtmlFile(String testDirectoryName, String[] expectedMessages) throws Exception {
-        String testDirectoryRelativePath = ABOUT_HTML_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName;
-        String testDirectoryAbsolutePath = getPath(testDirectoryRelativePath);
-        File testDirectory = new File(testDirectoryAbsolutePath);
-
-        String messageFilePath = testDirectoryAbsolutePath + File.separator + ABOUT_HTML_FILE_NAME;
+        File testDirectory = new File(getPath(testDirectoryName));
+        String messageFilePath = getPath(testDirectoryName) + File.separator + ABOUT_HTML_FILE_NAME;
 
         verify(createChecker(config), testDirectory.listFiles(), messageFilePath, expectedMessages);
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
@@ -8,14 +8,11 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.AnnotationDependencyCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -26,15 +23,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class AnnotationDependencyCheckTest extends AbstractStaticCheckTest {
 
-    private static final String TEST_DIRECTORY_NAME = "annotationDependencyCheckTest";
     private static final String EXPECTED_WARNING_MESSAGE = "Every bundle should have optional Import-Package dependency to org.eclipse.jdt.annotation.";
-    private static DefaultConfiguration checkConfiguration = createCheckConfig(AnnotationDependencyCheck.class);
+
+    private static DefaultConfiguration checkConfiguration = createModuleConfig(AnnotationDependencyCheck.class);
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration configuration) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(configuration);
-        return defaultConfiguration;
+    protected String getPackageLocation() {
+        return "checkstyle/annotationDependencyCheckTest";
     }
 
     @Test
@@ -58,7 +53,8 @@ public class AnnotationDependencyCheckTest extends AbstractStaticCheckTest {
     }
 
     private void checkFile(String fileName, String... expectedMessages) throws Exception {
-        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String filePath = getPath(fileName);
         verify(checkConfiguration, filePath, expectedMessages);
     }
+
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -30,7 +29,6 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
 
     private static final String EXPECTED_WARNING_MESSAGE_FIRST_AUTHOR_DESCRIPTION = "First javadoc author should have \"Initial contribution\" contribution description.";
     private static final String EXPECTED_WARNING_MESSAGE_OTHER_AUTHOR_DESCRIPTION = "Javadoc author should not have empty contribution description.";
-    private static final String TEST_DIRECTORY_NAME = "authorContributionDescriptionCheckTest";
 
     /**
      * The needed attributes for the configuration. They should be the same as their
@@ -44,10 +42,16 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
 
     private DefaultConfiguration configuration;
 
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/authorContributionDescriptionCheckTest";
+    }
+
     @Before
     public void setUp() {
         lineNumberToWarningMessageExpected = new TreeMap<>();
-        configuration = createCheckConfig(AuthorContributionDescriptionCheck.class);
+        configuration =  createModuleConfig(AuthorContributionDescriptionCheck.class);
         configuration.addAttribute(ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME, ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE);
     }
 
@@ -273,7 +277,7 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
     }
 
     private void checkFileForAuthorContributionDescription(boolean checkInnerUnits, String fileName) throws Exception {
-        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String filePath = getPath(fileName);
         String[] expected = null;
 
         if (lineNumberToWarningMessageExpected.isEmpty()) {

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
@@ -1,7 +1,5 @@
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.AuthorTagCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
@@ -18,6 +16,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class AuthorTagCheckTest extends AbstractStaticCheckTest {
 
     private static final String EXPECTED_WARNING_MESSAGE = "An author tag is missing";
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/authorTagCheckTest";
+    }
 
     @Test
     public void testOuterClassWithNoAuthorTag() throws Exception {
@@ -85,7 +88,7 @@ public class AuthorTagCheckTest extends AbstractStaticCheckTest {
     private void checkFileForAuthorTags(boolean checkInnerUnits, String fileName, Integer... warningLine)
             throws Exception {
 
-        String filePath = getPath("authorTagCheckTest"+ File.separator + fileName);
+        String filePath = getPath(fileName);
         String[] expected = null;
         if (warningLine.length > 0) {
             expected = new String[warningLine.length];
@@ -102,7 +105,7 @@ public class AuthorTagCheckTest extends AbstractStaticCheckTest {
 
     private DefaultConfiguration createConfiguration(boolean checkInnerUnits) {
 
-        DefaultConfiguration configuration = createCheckConfig(AuthorTagCheck.class);
+        DefaultConfiguration configuration = createModuleConfig(AuthorTagCheck.class);
         /*
          * Modify the configuration with the needed attributes and message. They
          * should be the same as their corresponding properties defined in

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
@@ -24,31 +24,29 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class AvoidScheduleAtFixedRateCheckTest extends AbstractStaticCheckTest {
 
     private static final String WARNING_MESSAGE = "For periodically executed jobs that do not require a fixed rate scheduleWithFixedDelay should be preferred over scheduleAtFixedRate.";
-    private static final String TEST_DIRECTORY_NAME = "avoidScheduleAtFixedRateCheckTest";
 
-    Configuration config = createCheckConfig(AvoidScheduleAtFixedRateCheck.class);
+    private final Configuration config = createModuleConfig(AvoidScheduleAtFixedRateCheck.class);
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/avoidScheduleAtFixedRateCheckTest";
+    }
 
     @Test
     public void verifyScheduleAtFixedRateUsed() throws Exception {
-        verifyJavaFile("ScheduleAtFixedRateUsed.java", generateExpectedMessages(11, WARNING_MESSAGE));
+        final String[] expected = generateExpectedMessages(11, WARNING_MESSAGE);
+        verify(config, getPath("ScheduleAtFixedRateUsed.java"), expected);
     }
 
     @Test
     public void verifyNoScheduledExecutorMethods() throws Exception {
-        verifyJavaFileNoErrors("NoScheduledExecutorServiceMethods.java");
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(config, getPath("NoScheduledExecutorServiceMethods.java"), expected);
     }
 
     @Test
     public void verifyScheduleWithFixedDelay() throws Exception {
-        verifyJavaFileNoErrors("ValidScheduleWithFixedDelay.java");
-    }
-
-    private void verifyJavaFile(String testFileName, String[] expectedMessages) throws Exception {
-        String absolutePathToTestFile = getPath(TEST_DIRECTORY_NAME + "/" + testFileName);
-        verify(config, absolutePathToTestFile, expectedMessages);
-    }
-
-    private void verifyJavaFileNoErrors(String testFileName) throws Exception {
-        verifyJavaFile(testFileName, CommonUtils.EMPTY_STRING_ARRAY);
+        final String[] expected = CommonUtils.EMPTY_STRING_ARRAY;
+        verify(config, getPath("ValidScheduleWithFixedDelay.java"), expected);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
@@ -8,7 +8,10 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.BIN_INCLUDES_PROPERTY_NAME;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.BUILD_PROPERTIES_FILE_NAME;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.OUTPUT_PROPERTY_NAME;
+import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.SOURCE_PROPERTY_NAME;
 
 import java.io.File;
 
@@ -19,7 +22,6 @@ import org.openhab.tools.analysis.checkstyle.BuildPropertiesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -29,8 +31,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Svilen Valkanov - Some minor fixes and improvements
  */
 public class BuildPropertiesCheckTest extends AbstractStaticCheckTest {
-    private static final String BUILD_PROPERTIES_CHECK_TEST_DIRECTORY_NAME = "buildPropertiesCheckTest";
-
     private static final String MISSING_PROPERTY_MSG = "Missing %s property in the %s file.";
     private static final String MISSING_VALUE_MSG = "Property  %s in the %s file is missing value: ";
     private static final String EMPTY_FILE_MSG = String.format("Empty %s file", BUILD_PROPERTIES_FILE_NAME);
@@ -45,13 +45,18 @@ public class BuildPropertiesCheckTest extends AbstractStaticCheckTest {
     private static final String MISSING_SRC_VALUE_MSG = String.format(MISSING_VALUE_MSG, SOURCE_PROPERTY_NAME,
             BUILD_PROPERTIES_FILE_NAME);
 
-    private static DefaultConfiguration config = createCheckConfig(BuildPropertiesCheck.class);
+    private static DefaultConfiguration config = createModuleConfig(BuildPropertiesCheck.class);
 
     @BeforeClass
     public static void setUpTest() {
         config.addAttribute("expectedBinIncludesValues", "META-INF/");
         config.addAttribute("possibleOutputValues", "target/classes,target/test-classes");
         config.addAttribute("possibleSourceValues", "src/main/java,src/main/resources,src/test/java,src/test/groovy");
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/buildPropertiesCheckTest";
     }
 
     @Test
@@ -93,18 +98,9 @@ public class BuildPropertiesCheckTest extends AbstractStaticCheckTest {
         verifyBuildPropertiesFile("empty_build_properties_file_directory", 0, EMPTY_FILE_MSG);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
-    }
-
     private void verifyBuildPropertiesFile(String testDirectoryName, int expectedLine, String expectedMessage)
             throws Exception {
-        String testDirectoryRelativePath = BUILD_PROPERTIES_CHECK_TEST_DIRECTORY_NAME + File.separator
-                + testDirectoryName;
-        String testDirectoryAbsolutePath = getPath(testDirectoryRelativePath);
+        String testDirectoryAbsolutePath = getPath(testDirectoryName);
         File testDirectory = new File(testDirectoryAbsolutePath);
         File[] filesToCheck = FileUtils.listFiles(testDirectory, null, true).toArray(new File[] {});
 

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesExternalLibrariesCheckTest.java
@@ -16,8 +16,6 @@ import org.openhab.tools.analysis.checkstyle.BuildPropertiesExternalLibrariesChe
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -27,80 +25,65 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class BuildPropertiesExternalLibrariesCheckTest extends AbstractStaticCheckTest {
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(
-            BuildPropertiesExternalLibrariesCheck.class);
+    private static final DefaultConfiguration CONFIGURATION = createModuleConfig(BuildPropertiesExternalLibrariesCheck.class);
     private static final String TEST_FILE_NAME = "build.properties";
-    private static final String MAIN_DIRECTORY = "buildPropertiesExternalLibrariesCheck";
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/buildPropertiesExternalLibrariesCheck";
     }
 
     @Test
     public void shouldNotLogWhenBundleIsValidFolder() throws Exception {
-        final String VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator + "validBundle";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
         verifyNoWarningMessages(warningMessages,
-                getBuildPropertiesPath(VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES));
+                getBuildPropertiesPathForDirectory("validBundle"));
     }
 
     @Test
     public void shouldNotLogWhenBundleIsValidEntries() throws Exception {
-        final String VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator
-                + "validBundleWithJarFilesInBuildProperties";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
         verifyNoWarningMessages(warningMessages,
-                getBuildPropertiesPath(VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES));
+                getBuildPropertiesPathForDirectory("validBundleWithJarFilesInBuildProperties"));
     }
 
     @Test
     public void shouldLogWhenThereAreMissingFilesInBuildProperties() throws Exception {
-        final String BUNDLE_WITH_MISSING_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator
-                + "bundleWithMissingJarFilesFromBuildProperties";
         String message = "The jar file lib/test2.jar is present in the lib folder but is not present in the build properties";
         String[] warningMessages = generateExpectedMessages(0, message);
-        verifyNoWarningMessages(warningMessages, getBuildPropertiesPath(BUNDLE_WITH_MISSING_FILES_IN_BUILD_PROPERTIES));
+        verifyNoWarningMessages(warningMessages, getBuildPropertiesPathForDirectory("bundleWithMissingJarFilesFromBuildProperties"));
     }
 
     @Test
     public void shouldNotLogWhenBundleDoesNotContainExternalDependancies() throws Exception {
-        final String BUNDLE_WITHOUT_EXTERNAL_DEPENDANCIES = MAIN_DIRECTORY + File.separator + "emptyBundle";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyNoWarningMessages(warningMessages, getBuildPropertiesPath(BUNDLE_WITHOUT_EXTERNAL_DEPENDANCIES));
+        verifyNoWarningMessages(warningMessages, getBuildPropertiesPathForDirectory("emptyBundle"));
     }
 
     @Test
     public void shouldLogWhenThereAreMissingJarFilesFromLib() throws Exception {
-        final String BUNDLE_WITH_MISSING_JAR_FILES_FROM_LIB = MAIN_DIRECTORY + File.separator
-                + "bundleWithMissingFilesFromLibFolderWithBuildProperties";
         String message = "The file lib/test2.jar is present in the build properties but not in the lib folder.";
         String[] warningMessages = generateExpectedMessages(0, message);
-        verifyNoWarningMessages(warningMessages, getBuildPropertiesPath(BUNDLE_WITH_MISSING_JAR_FILES_FROM_LIB));
+        verifyNoWarningMessages(warningMessages, getBuildPropertiesPathForDirectory("bundleWithMissingFilesFromLibFolderWithBuildProperties"));
     }
 
     @Test
     public void shouldNotLogWhenThereAreExcludedJarFiles() throws Exception {
-        final String BUNDLE_WITH_EXCLUDED_JARS = MAIN_DIRECTORY + File.separator + "bundleWithExcludedFiles";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyNoWarningMessages(warningMessages, getBuildPropertiesPath(BUNDLE_WITH_EXCLUDED_JARS));
+        verifyNoWarningMessages(warningMessages, getBuildPropertiesPathForDirectory("bundleWithExcludedFiles"));
     }
 
     @Test
     public void shouldNotLogWhenThereAreSpacesInBuildProperties() throws Exception {
-        final String BUNDLE_WITH_SPACES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator
-                + "bundleWithSpacesInBuildProperties";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyNoWarningMessages(warningMessages, getBuildPropertiesPath(BUNDLE_WITH_SPACES_IN_BUILD_PROPERTIES));
+        verifyNoWarningMessages(warningMessages, getBuildPropertiesPathForDirectory("bundleWithSpacesInBuildProperties"));
     }
 
     private void verifyNoWarningMessages(String[] warningMessages, String filePath) throws Exception {
         verify(CONFIGURATION, filePath, warningMessages);
     }
 
-    private String getBuildPropertiesPath(String bundlePath) throws IOException {
-        return getPath(bundlePath + File.separator + TEST_FILE_NAME);
+    private String getBuildPropertiesPathForDirectory(String directoryName) throws IOException {
+        return getPath(directoryName + File.separator + TEST_FILE_NAME);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
@@ -8,13 +8,12 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.BundleVendorCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
  * Tests for {@link BundleVendorCheck}
@@ -22,8 +21,7 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
  * @author Martin van Wingerden
  */
 public class BundleVendorCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY = "correctOpenHABSpellingInManifestTest/";
-    private static final DefaultConfiguration checkConfig = createCheckConfig(BundleVendorCheck.class);
+    private static final DefaultConfiguration checkConfig = createModuleConfig(BundleVendorCheck.class);
 
     @BeforeClass
     public static void setUpClass() {
@@ -31,10 +29,8 @@ public class BundleVendorCheckTest extends AbstractStaticCheckTest {
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/correctOpenHABSpellingInManifestTest";
     }
 
     @Test
@@ -95,7 +91,7 @@ public class BundleVendorCheckTest extends AbstractStaticCheckTest {
 
     private void verify(String fileName, String[] expectedMessages) throws Exception {
         verify(checkConfig,
-                getPath(TEST_DIRECTORY + fileName),
+                getPath(fileName),
                 expectedMessages
         );
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
@@ -21,10 +21,14 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
  *
  */
 public class DeclarativeServicesDependencyInjectionCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_RESOURCES_DIR = "declarativeServicesDependencyInjectionTest";
 
     private static final String SERVICE_TRACKER_USED = "Avoid using ServiceTracker for dependency injection, consider using Declarative Services";
     private static final String SERVICE_CUSTOMIZER_IMPLEMENTED = "Avoid using ServiceTrackerCustomizer for dependency injection, consider using Declarative Services";
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/declarativeServicesDependencyInjectionTest";
+    }
 
     @Test
     public void testServiceTrackerInjection() throws Exception {
@@ -66,11 +70,10 @@ public class DeclarativeServicesDependencyInjectionCheckTest extends AbstractSta
     }
 
     private void verifyFile(String testFileName, String[] expectedMessages) throws Exception {
-        DefaultConfiguration config = createCheckConfig(DeclarativeServicesDependencyInjectionCheck.class);
+        DefaultConfiguration config = createModuleConfig(DeclarativeServicesDependencyInjectionCheck.class);
 
-        String filePath = getPath(TEST_RESOURCES_DIR + "/" + testFileName);
+        String filePath = getPath(testFileName);
 
         verify(config, filePath, expectedMessages);
     }
-
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlUsageCheckTest.java
@@ -20,7 +20,6 @@ import org.openhab.tools.analysis.checkstyle.EshInfXmlValidationCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Test for {@link EshInfXmlValidationCheck}
@@ -31,12 +30,8 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  */
 public class EshInfXmlUsageCheckTest extends AbstractStaticCheckTest {
 
-    private static final String TEST_CHECK_DIRECTORY = "eshInfXmlUsageCheckTest" + File.separator;
-
     private static final String RELATIVE_PATH_TO_THING = File.separator + ESH_INF_DIRECTORY + File.separator
             + EshInfXmlValidationCheck.THING_DIRECTORY + File.separator + "thing-types.xml";
-    private static final String RELATIVE_PATH_TO_BINDING = File.separator + ESH_INF_DIRECTORY + File.separator
-            + EshInfXmlValidationCheck.BINDING_DIRECTORY + File.separator + "bind.xml";
     private static final String RELATIVE_PATH_TO_CONFIG = File.separator + ESH_INF_DIRECTORY + File.separator
             + EshInfXmlValidationCheck.CONFIGURATION_DIRECTORY + File.separator + "conf.xml";
 
@@ -45,13 +40,11 @@ public class EshInfXmlUsageCheckTest extends AbstractStaticCheckTest {
     private static final String MESSAGE_UNUSED_URI_CONFIGURATION = "Unused configuration reference with uri - {0}";
     private static final String MESSAGE_UNUSED_BRIDGE = "Unused bridge reference with id - {0}";
 
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(EshInfXmlUsageCheck.class);
+    private static final DefaultConfiguration CONFIGURATION = createModuleConfig(EshInfXmlUsageCheck.class);
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/eshInfXmlUsageCheckTest";
     }
 
     @Test
@@ -83,7 +76,7 @@ public class EshInfXmlUsageCheckTest extends AbstractStaticCheckTest {
 
     private void verifyWithPath(String testSubDirectory, String testFilePath, String[] expectedMessages)
             throws Exception {
-        String directoryPath = getPath(TEST_CHECK_DIRECTORY + testSubDirectory);
+        String directoryPath = getPath(testSubDirectory);
         File testDirectoryPath = new File(directoryPath);
 
         File[] testFiles = listFilesForFolder(testDirectoryPath, new ArrayList<File>());

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlValidationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlValidationCheckTest.java
@@ -25,7 +25,6 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 import org.openhab.tools.analysis.utils.CachingHttpClient;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -36,8 +35,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class EshInfXmlValidationCheckTest extends AbstractStaticCheckTest {
-
-    private static final String TEST_CHECK_DIRECTORY = "eshInfXmlValidationCheckTest" + File.separator;
 
     private static final String RELATIVE_PATH_TO_THING = File.separator + ESH_INF_DIRECTORY + File.separator
             + EshInfXmlValidationCheck.THING_DIRECTORY + File.separator + "thing-types.xml";
@@ -54,13 +51,18 @@ public class EshInfXmlValidationCheckTest extends AbstractStaticCheckTest {
     private static final String MESSAGE_EMPTY_FILE = "The file {0} should not be empty.";
     private static final String MESSAGE_NOT_INCLUDED_XML_FILE = "The file {0} isn't included in the build.properties file. Good approach is to include all files by adding `ESH-INF/` value to the bin.includes property.";
 
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(EshInfXmlValidationCheck.class);
+    private static final DefaultConfiguration CONFIGURATION = createModuleConfig(EshInfXmlValidationCheck.class);
 
     @BeforeClass
     public static void createConfiguration() {
         CONFIGURATION.addAttribute("thingSchema", THING_SCHEMA_URL);
         CONFIGURATION.addAttribute("bindingSchema", BINDING_SCHEMA_URL);
         CONFIGURATION.addAttribute("configSchema", CONFIG_SCHEMA_URL);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/eshInfXmlValidationCheckTest";
     }
 
     private boolean isResourceAvailable;
@@ -74,13 +76,6 @@ public class EshInfXmlValidationCheckTest extends AbstractStaticCheckTest {
         } catch (IOException e) {
             isResourceAvailable = false;
         }
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
     }
 
     @Test
@@ -206,7 +201,7 @@ public class EshInfXmlValidationCheckTest extends AbstractStaticCheckTest {
 
     private void verifyWithPath(String testSubDirectory, String testFilePath, String[] expectedMessages)
             throws Exception {
-        String directoryPath = getPath(TEST_CHECK_DIRECTORY + testSubDirectory);
+        String directoryPath = getPath(testSubDirectory);
         File testDirectoryPath = new File(directoryPath);
 
         File[] testFiles = listFilesForFolder(testDirectoryPath, new ArrayList<File>());

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
@@ -8,16 +8,12 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.ExportInternalPackageCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -28,20 +24,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY_NAME = "exportInternalPackageCheckTest";
-
     private static DefaultConfiguration config;
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
-    }
 
     @BeforeClass
     public static void setUpClass() {
-        config = createCheckConfig(ExportInternalPackageCheck.class);
+        config = createModuleConfig(ExportInternalPackageCheck.class);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/exportInternalPackageCheckTest";
     }
 
     @Test
@@ -84,8 +76,7 @@ public class ExportInternalPackageCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyManifest(String fileName, String[] expectedMessages) throws Exception {
-        String testFileRelativePath = TEST_DIRECTORY_NAME + File.separator + fileName;
-        String testFileAbsolutePath = getPath(testFileRelativePath);
+        String testFileAbsolutePath = getPath(fileName);
         verify(config, testFileAbsolutePath, expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
 import java.text.MessageFormat;
 
 import org.junit.BeforeClass;
@@ -17,7 +16,6 @@ import org.openhab.tools.analysis.checkstyle.ImportExportedPackagesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -27,14 +25,18 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY_NAME = "importExportedPackagesCheckTest";
     private static final String NOT_IMPORTED_PACKAGE_MESSAGE = "The exported package `{0}` is not imported";
 
     private static DefaultConfiguration configuration;
 
     @BeforeClass
     public static void setUp() {
-        configuration = createCheckConfig(ImportExportedPackagesCheck.class);
+        configuration = createModuleConfig(ImportExportedPackagesCheck.class);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/importExportedPackagesCheckTest";
     }
 
     @Test
@@ -85,14 +87,7 @@ public class ImportExportedPackagesCheckTest extends AbstractStaticCheckTest {
     }
 
     public void verifyManifestFile(String fileName, String[] warningMessages) throws Exception {
-        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String filePath = getPath(fileName);
         verify(configuration, filePath, warningMessages);
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration dc = new DefaultConfiguration("root");
-        dc.addChild(config);
-        return dc;
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
@@ -25,9 +23,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class InheritDocCheckTest extends AbstractStaticCheckTest {
     private final static String LOG_MESSAGE = "Remove unnecessary inherit doc";
-    private final static String TEST_DIRECTORY_NAME = "inheritDocCheckTest";
 
-    Configuration config = createCheckConfig(InheritDocCheck.class);
+    Configuration config = createModuleConfig(InheritDocCheck.class);
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/inheritDocCheckTest";
+    }
 
     @Test
     public void shouldLogWhenThereIsAnEmptyInheritDoc() throws Exception {
@@ -55,7 +57,7 @@ public class InheritDocCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyJavadoc(String testFileName, String[] expectedMessages) throws Exception {
-        String absolutePathToTestFile = getPath(TEST_DIRECTORY_NAME + File.separator + testFileName);
+        String absolutePathToTestFile = getPath(testFileName);
         verify(config, absolutePathToTestFile, expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocFilterCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocFilterCheckTest.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.JavadocFilterCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
@@ -25,6 +23,11 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class JavadocFilterCheckTest extends AbstractStaticCheckTest {
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/javadocFilterCheckTest";
+    }
     @Test
     public void testOuterClassWithJavadoc() throws Exception {
         int[] lineNumbers = new int[] { 10 };
@@ -48,12 +51,11 @@ public class JavadocFilterCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyJavadoc(String testFileName, boolean checkInnerClasses, int[] lineNumbers) throws Exception {
-        DefaultConfiguration config = createCheckConfig(JavadocFilterCheck.class);
+        DefaultConfiguration config = createModuleConfig(JavadocFilterCheck.class);
         String checkInnerClassesPropertyName = "checkInnerUnits";
         config.addAttribute(checkInnerClassesPropertyName, String.valueOf(checkInnerClasses));
 
-        String testDirectory = "javadocFilterCheckTest";
-        String filePath = getPath(testDirectory + File.separator + testFileName);
+        String filePath = getPath(testFileName);
 
         String[] expectedMessages = null;
         if (lineNumbers != null) {

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.JavadocMethodStyleCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
@@ -28,9 +26,13 @@ public class JavadocMethodStyleCheckTest extends AbstractStaticCheckTest {
     private static final String EXPECTED_MESSAGE_CONTAINS_DASH = "There should be no dash between the parameter name and the description in a Javadoc comment of a method or constructor.";
     private static final String EXPECTED_MESSAGE_EMPTY_LINES_BETWEEN_TAGS = "There should be no empty lines between tags in a Javadoc comment of a method or constructor.";
     private static final String EXPECTED_MESSAGE_PARAMETER_DESCRIPTION_NEWLINE = "The parameter description in a Javadoc comment of a method or constructor should not start on a new line.";
-    private static final String TEST_DIRECTORY_NAME = "javadocMethodStyleCheckTest";
 
-    private DefaultConfiguration configuration = createCheckConfig(JavadocMethodStyleCheck.class);
+    private DefaultConfiguration configuration = createModuleConfig(JavadocMethodStyleCheck.class);
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/javadocMethodStyleCheckTest";
+    }
 
     @Test
     public void testMethodJavadocWithDashBetweenParameterNameAndParameterDescription() throws Exception {
@@ -132,7 +134,7 @@ public class JavadocMethodStyleCheckTest extends AbstractStaticCheckTest {
     }
 
     private void checkFile(String fileName, String[] expectedMessages) throws Exception {
-        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String filePath = getPath(fileName);
         verify(configuration, filePath, expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
@@ -8,7 +8,8 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.POM_XML_FILE_NAME;
@@ -34,7 +35,6 @@ import org.openhab.tools.analysis.checkstyle.KarafFeatureCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Tests for {@link KarafFeatureCheck}
@@ -51,19 +51,16 @@ public class KarafFeatureCheckTest extends AbstractStaticCheckTest {
     private ArgumentCaptor<LogRecord> captor;
 
     private static final String MSG_MISSING_BUNDLE_IN_FEATURE_XML = "Bundle with ID '{0}' must be added in {1}";
-    private static final String TEST_DIRECTORY = "karafFeatureCheck";
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(KarafFeatureCheck.class);
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
-    }
+    private static final DefaultConfiguration CONFIGURATION = createModuleConfig(KarafFeatureCheck.class);
 
     @BeforeClass
     public static void setUp() {
         CONFIGURATION.addAttribute("featureXmlPath", "feature/feature.xml");
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/karafFeatureCheck";
     }
 
     @Before
@@ -108,7 +105,7 @@ public class KarafFeatureCheckTest extends AbstractStaticCheckTest {
 
     private void verify(String fileDirectory, String[] expectedMessages) throws Exception {
         verify(CONFIGURATION,
-                getPath(TEST_DIRECTORY + File.separator + fileDirectory + File.separator + POM_XML_FILE_NAME),
+                getPath(fileDirectory + File.separator + POM_XML_FILE_NAME),
                 expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestExternalLibrariesCheckTest.java
@@ -16,8 +16,6 @@ import org.openhab.tools.analysis.checkstyle.ManifestExternalLibrariesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -27,86 +25,72 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class ManifestExternalLibrariesCheckTest extends AbstractStaticCheckTest {
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(ManifestExternalLibrariesCheck.class);
+    private static final DefaultConfiguration CONFIGURATION = createModuleConfig(ManifestExternalLibrariesCheck.class);
     private static String TEST_FILE_NAME = "MANIFEST.MF";
-    private static final String MAIN_DIRECTORY = "manifestExternalLibrariesCheck";
+    private static final String TEST_FOLDER_NAME = "META-INF";
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/manifestExternalLibrariesCheck";
     }
 
     @Test
     public void shouldNotLogWhenBundleIsValid() throws Exception {
-        final String VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator + "validBundle"
-                + File.separator + "META-INF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyManifest(getManifestFilePath(VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("validBundle")), warningMessages);
     }
 
     @Test
     public void shouldLogWhenBundleIsMissingLibFolder() throws Exception {
-        final String BUNDLE_WITH_MISSING_LIB_FOLDER = MAIN_DIRECTORY + File.separator + "bundleWithoutLibFolder"
-                + File.separator + "META-INF";
         String message = "All jar files need to be placed inside a lib folder.";
         String[] warningMessages = generateExpectedMessages(0, message);
-        verifyManifest(getManifestFilePath(BUNDLE_WITH_MISSING_LIB_FOLDER), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithoutLibFolder")), warningMessages);
     }
 
     @Test
     public void shouldLogWhenBundleIsMissingFilesFromLibFolder() throws Exception {
-        final String BUNDLE_WITH_MISSING_FILES_FROM_LIB_FOLDER = MAIN_DIRECTORY + File.separator
-                + "bundleWithMissingFilesFromLibFolder" + File.separator + "META-INF";
         String message = "The jar file lib/test2.jar is not present in the lib folder";
         String[] warningMessages = generateExpectedMessages(0, message);
-        verifyManifest(getManifestFilePath(BUNDLE_WITH_MISSING_FILES_FROM_LIB_FOLDER), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithMissingFilesFromLibFolder")), warningMessages);
     }
 
     @Test
     public void shouldNotLogWhenThereAreNoExternalLibraries() throws Exception {
-        final String BUNDLE_WITHOUT_EXTERNAL_DEPENDANCIES = MAIN_DIRECTORY + File.separator
-                + "bundleWithoutExternalLibraries" + File.separator + "META-INF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyManifest(getManifestFilePath(BUNDLE_WITHOUT_EXTERNAL_DEPENDANCIES), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithoutExternalLibraries")), warningMessages);
     }
 
     @Test
     public void shouldLogWhenThereAreMissingFilesInManifest() throws Exception {
-        final String BUNDLE_WITH_MISSING_FILES_IN_MANIFEST = MAIN_DIRECTORY + File.separator
-                + "bundleWithMissingFilesInManifest" + File.separator + "META-INF";
         String message = "The jar file lib/test2.jar is present in the lib folder but is not present in the MANIFEST.MF file";
         String[] warningMessages = generateExpectedMessages(0, message);
-        verifyManifest(getManifestFilePath(BUNDLE_WITH_MISSING_FILES_IN_MANIFEST), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithMissingFilesInManifest")), warningMessages);
     }
 
     @Test
     public void shouldNotLogWhenThereAreExcludedFiles() throws Exception {
-        final String BUNDLE_WITH_EXCLUDED_FILES = MAIN_DIRECTORY + File.separator + "bundleWithExcludedFiles"
-                + File.separator + "META-INF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyManifest(getManifestFilePath(BUNDLE_WITH_EXCLUDED_FILES), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithExcludedFiles")), warningMessages);
     }
 
     @Test
     public void shouldNotLogWhenThereAreSpacesInManifest() throws Exception {
-        final String BUNDLE_WITH_SPACES_IN_MANIFEST = MAIN_DIRECTORY + File.separator + "bundleWithSpacesInManifest"
-                + File.separator + "META-INF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyManifest(getManifestFilePath(BUNDLE_WITH_SPACES_IN_MANIFEST), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithSpacesInManifest")), warningMessages);
     }
 
     @Test
     public void shouldNotLogWhenBundleHasVariousBundleClasspathEntries() throws Exception {
-        final String VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator
-                + "bundleWithVariousBundleClasspathEntries" + File.separator + "META-INF";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyManifest(getManifestFilePath(VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES), warningMessages);
+        verifyManifest(getManifestFilePathFromFolder(addMetaInfToFilePath("bundleWithVariousBundleClasspathEntries")), warningMessages);
     }
 
-    private String getManifestFilePath(String bundlePath) throws IOException {
-        return getPath(bundlePath + File.separator + TEST_FILE_NAME);
+    private String getManifestFilePathFromFolder(String folderName) throws IOException {
+        return getPath(folderName + File.separator + TEST_FILE_NAME);
+    }
+
+    private String addMetaInfToFilePath(String filePath) throws IOException {
+        return filePath + File.separator + TEST_FOLDER_NAME;
     }
 
     private void verifyManifest(String filePath, String[] warningMessages) throws Exception {

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
@@ -8,14 +8,13 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.BundleVendorCheck;
 import org.openhab.tools.analysis.checkstyle.ManifestJavaVersionCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
 
 /**
  * Tests for {@link BundleVendorCheck}
@@ -23,8 +22,7 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
  * @author Martin van Wingerden
  */
 public class ManifestJavaVersionCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY = "manifestJavaVersionCheckTest/";
-    private static final DefaultConfiguration checkConfig = createCheckConfig(ManifestJavaVersionCheck.class);
+    private static final DefaultConfiguration checkConfig = createModuleConfig(ManifestJavaVersionCheck.class);
 
     @BeforeClass
     public static void setUpClass() {
@@ -32,10 +30,8 @@ public class ManifestJavaVersionCheckTest extends AbstractStaticCheckTest {
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/manifestJavaVersionCheckTest";
     }
 
     @Test
@@ -96,7 +92,7 @@ public class ManifestJavaVersionCheckTest extends AbstractStaticCheckTest {
 
     private void verify(String fileName, String[] expectedMessages) throws Exception {
         verify(checkConfig,
-                getPath(TEST_DIRECTORY + fileName),
+                getPath(fileName),
                 expectedMessages
         );
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
@@ -18,7 +18,6 @@ import org.openhab.tools.analysis.checkstyle.ManifestPackageVersionCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -35,16 +34,14 @@ public class ManifestPackageVersionCheckTest extends AbstractStaticCheckTest {
 
     @BeforeClass
     public static void createConfiguration() {
-        config = createCheckConfig(ManifestPackageVersionCheck.class);
+        config = createModuleConfig(ManifestPackageVersionCheck.class);
         config.addAttribute("ignoreImportedPackages", "org.apache.*, org.junit.*");
         config.addAttribute("ignoreExportedPackages", "org.eclipse.smarthome.tool.*");
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/manifestPackageVersionCheckTest";
     }
 
     @Test
@@ -107,9 +104,7 @@ public class ManifestPackageVersionCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyManifest(String testFileDirectory, String[] expectedMessages) throws Exception {
-        String versionCheckTestDirectory = "manifestPackageVersionCheckTest";
-        String filePath = getPath(
-                versionCheckTestDirectory + File.separator + testFileDirectory + File.separator + MANIFEST_FILE_NAME);
+        String filePath = getPath(testFileDirectory + File.separator + MANIFEST_FILE_NAME);
 
         verify(config, filePath, expectedMessages);
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -20,7 +20,6 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 import org.openhab.tools.analysis.checkstyle.readme.MarkdownCheck;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Tests for {@link MarkdownCheck}
@@ -29,7 +28,6 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  * @author Lyubomir Papazov - Added more tests
  */
 public class MarkdownCheckTest extends AbstractStaticCheckTest {
-    private static final String README_MD_CHECK_TEST_DIRECTORY_NAME = "markdownCheckTest";
     private static final String ADDED_README_IN_BUILD_PROPERTIES_MSG = "README.MD file must not be added to the bin.includes property";
     private static final String ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG = "The doc folder must not be added to the bin.includes property";
     private DefaultConfiguration config;
@@ -37,6 +35,11 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     @Before
     public void setUpClass() {
         createValidConfig();
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/markdownCheckTest";
     }
 
     @Test
@@ -265,27 +268,20 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
 
     private void verifyBuildProperties(String[] expectedMessages, String testDirectoryName)
             throws IOException, Exception {
-        String testDirectoryAbsolutePath = getPath(README_MD_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName);
+        String testDirectoryAbsolutePath = getPath(testDirectoryName);
         String messageFilePath = testDirectoryAbsolutePath + File.separator + "build.properties";
         verify(createChecker(config), messageFilePath, expectedMessages);
     }
 
     private void createValidConfig() {
-        config = createCheckConfig(MarkdownCheck.class);
+        config = createModuleConfig(MarkdownCheck.class);
     }
-
+    
     private void verifyMarkDownFile(String testDirectoryName, String[] expectedMessages) throws Exception {
-        String testDirectoryRelativePath = README_MD_CHECK_TEST_DIRECTORY_NAME + File.separator + testDirectoryName
+        String testDirectoryRelativePath =  testDirectoryName
                 + File.separator + README_MD_FILE_NAME;
         String testDirectoryAbsolutePath = getPath(testDirectoryRelativePath);
         String messageFilePath = testDirectoryAbsolutePath;
         verify(createChecker(config), testDirectoryAbsolutePath, messageFilePath, expectedMessages);
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MavenPomderivedInClasspathCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MavenPomderivedInClasspathCheckTest.java
@@ -18,7 +18,6 @@ import org.openhab.tools.analysis.checkstyle.MavenPomderivedInClasspathCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -28,20 +27,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class MavenPomderivedInClasspathCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY_NAME = "mavenPomDerivedInClasspathCheckTest";
-
     private static DefaultConfiguration config;
 
     @BeforeClass
     public static void createConfiguration() {
-        config = createCheckConfig(MavenPomderivedInClasspathCheck.class);
+        config = createModuleConfig(MavenPomderivedInClasspathCheck.class);
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/mavenPomDerivedInClasspathCheckTest";
     }
 
     @Test
@@ -73,9 +68,7 @@ public class MavenPomderivedInClasspathCheckTest extends AbstractStaticCheckTest
     }
 
     private void verifyClasspath(String classpathDirectoryName, String[] expectedMessages) throws Exception {
-        String pomXmlAbsolutePath = getPath(
-                TEST_DIRECTORY_NAME + File.separator + classpathDirectoryName + File.separator + CLASSPATH_FILE_NAME);
+        String pomXmlAbsolutePath = getPath(classpathDirectoryName + File.separator + CLASSPATH_FILE_NAME);
         verify(config, pomXmlAbsolutePath, expectedMessages);
     }
-
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
@@ -23,13 +23,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  */
 public class NoEmptyLineSeparatorCheckTest extends AbstractStaticCheckTest {
 
-    private static final String TEST_DIRECTORY_NAME = "noEmptyLineSeparatorCheck";
-
     private static final String MSG_LINE_AFTER_OPENING_BRACE_EMPTY = "Remove empty line after opening brace";
     private static final String MSG_LINE_BEFORE_CLOSING_BRACE_EMPTY = "Remove empty line before closing brace";
     private static final String MSG_FOR_EMPTY_LINE = "Remove empty line";
 
-    private static DefaultConfiguration config = createCheckConfig(NoEmptyLineSeparatorCheck.class);
+    private static DefaultConfiguration config = createModuleConfig(NoEmptyLineSeparatorCheck.class);
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/noEmptyLineSeparatorCheck";
+    }
 
     @Test
     public void verifyValidSwitchDefinitionWithoutBraces() throws Exception {
@@ -234,7 +237,7 @@ public class NoEmptyLineSeparatorCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verifyJavaFile(String testFileName, String[] expectedMessages) throws Exception {
-        String absolutePathToTestFile = getPath(TEST_DIRECTORY_NAME + "/" + testFileName);
+        String absolutePathToTestFile = getPath(testFileName);
         verify(config, absolutePathToTestFile, expectedMessages);
     }
 

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationInXmlFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationInXmlFilesCheckTest.java
@@ -10,16 +10,12 @@ package org.openhab.tools.analysis.checkstyle.test;
 
 import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_STRING_ARRAY;
 
-import java.io.File;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.OnlyTabIndentationInXmlFilesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
-import org.openhab.tools.analysis.checkstyle.api.CheckConstants;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Checks whether whitespace characters are use instead of tabs in xml files
@@ -31,46 +27,50 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
 public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTest {
 
     private static final String WHITESPACE_USAGE_WARNING = "There were whitespace characters used for indentation. Please use tab characters instead";
-    private static final String TABIDENT_CHECK_TEST_DIRECTORY_NAME = "onlyTabIndentationInXmlFilesCheck";
     private DefaultConfiguration config;
 
     @Before
     public void setUpClass() {
-        config = createCheckConfig(OnlyTabIndentationInXmlFilesCheck.class);
+        config = createModuleConfig(OnlyTabIndentationInXmlFilesCheck.class);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/onlyTabIndentationInXmlFilesCheck";
     }
 
     @Test
     public void testOneLineXmlFile() throws Exception {
-        verifyXmlTabIdentation("WhiteSpacesNotUsedBeforeOpeningTags", noMessagesExpected());
+        verifyXmlTabIdentation("WhiteSpacesNotUsedBeforeOpeningTags.xml", noMessagesExpected());
     }
 
     @Test
     public void testOneIncorrectLine() throws Exception {
         String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInOneLine", expectedMessages);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInOneLine.xml", expectedMessages);
     }
 
     @Test
     public void testManyIncorrectLinesOnlyShowFirstWarning() throws Exception {
         String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines", expectedMessages);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines.xml", expectedMessages);
     }
 
     @Test
     public void testManyIncorrectLinesShowAllWarnings() throws Exception {
         String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING, 6, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines", expectedMessages, false);
+        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines.xml", expectedMessages, false);
     }
 
     @Test
     public void testXmlWithEmptyLinesAndComments() throws Exception {
-        String fileName = "BasicModuleHandlerFactory";
+        String fileName = "BasicModuleHandlerFactory.xml";
         verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
     public void testXmlWithMultipleLinesWithSpacesEmptyLinesAndComments() throws Exception {
-        String fileName = "ScriptEngineManager";
+        String fileName = "ScriptEngineManager.xml";
         String[] expectedMessages = generateExpectedMessages(3, WHITESPACE_USAGE_WARNING, 4, WHITESPACE_USAGE_WARNING,
                 6, WHITESPACE_USAGE_WARNING, 7, WHITESPACE_USAGE_WARNING, 9, WHITESPACE_USAGE_WARNING, 10,
                 WHITESPACE_USAGE_WARNING, 11, WHITESPACE_USAGE_WARNING, 13, WHITESPACE_USAGE_WARNING, 17,
@@ -81,19 +81,19 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
 
     @Test
     public void testXmlWithOnlyTabsForIndentation() throws Exception {
-        String fileName = "binding";
+        String fileName = "binding.xml";
         verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
     public void testAnotherXmlWithOnlyTabsForIndentation() throws Exception {
-        String fileName = "thing-types";
+        String fileName = "thing-types.xml";
         verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
     public void testXmlWithCDATAAndSpacesForIndentation() throws Exception {
-        String fileName = "i18n";
+        String fileName = "i18n.xml";
         String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING, 11, WHITESPACE_USAGE_WARNING,
                 12, WHITESPACE_USAGE_WARNING, 13, WHITESPACE_USAGE_WARNING, 14, WHITESPACE_USAGE_WARNING, 20,
                 WHITESPACE_USAGE_WARNING, 21, WHITESPACE_USAGE_WARNING, 22, WHITESPACE_USAGE_WARNING, 23,
@@ -106,7 +106,7 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
 
     @Test
     public void testAnotherXmlWithCDATAAndSpacesForIndentation() throws Exception {
-        String fileName = "bridge";
+        String fileName = "bridge.xml";
         String[] expectedMessages = generateExpectedMessages(10, WHITESPACE_USAGE_WARNING, 11, WHITESPACE_USAGE_WARNING,
                 12, WHITESPACE_USAGE_WARNING, 13, WHITESPACE_USAGE_WARNING, 15, WHITESPACE_USAGE_WARNING, 16,
                 WHITESPACE_USAGE_WARNING, 17, WHITESPACE_USAGE_WARNING, 18, WHITESPACE_USAGE_WARNING, 19,
@@ -121,9 +121,7 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
 
     private void verifyXmlTabIdentation(String fileName, String[] expectedMessages, boolean onlyShowFirstWarning)
             throws Exception {
-        String testFileRelativePath = TABIDENT_CHECK_TEST_DIRECTORY_NAME + File.separator + fileName + "."
-                + CheckConstants.XML_EXTENSION;
-        String testFileAbsolutePath = getPath(testFileRelativePath);
+        String testFileAbsolutePath = getPath(fileName);
         String messageFilePath = testFileAbsolutePath;
         if (onlyShowFirstWarning) {
             config.addAttribute("onlyShowFirstWarning", "true");
@@ -135,12 +133,5 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
 
     private void verifyXmlTabIdentation(String fileName, String[] expectedMessages) throws Exception {
         verifyXmlTabIdentation(fileName, expectedMessages, true);
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
@@ -17,8 +17,6 @@ import org.openhab.tools.analysis.checkstyle.OutsideOfLibExternalLibrariesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -28,23 +26,19 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class OutsideOfLibExternalLibrariesCheckTest extends AbstractStaticCheckTest {
-    private static final DefaultConfiguration CONFIGURATION = createCheckConfig(
-            OutsideOfLibExternalLibrariesCheck.class);
     private static String TEST_FILE_NAME = "build.properties";
-    private static final String MAIN_DIRECTORY = "outsideOfLibExternalLibrariesCheck";
     private static DefaultConfiguration config;
+    
+
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/outsideOfLibExternalLibrariesCheck";
     }
 
     @BeforeClass
     public static void setUpClass() {
-        config = createCheckConfig(OutsideOfLibExternalLibrariesCheck.class);
+        config = createModuleConfig(OutsideOfLibExternalLibrariesCheck.class);
 
         String ignoredDirectoriesValue = "bin,target";
         config.addAttribute("ignoredDirectories", ignoredDirectoriesValue);
@@ -52,20 +46,17 @@ public class OutsideOfLibExternalLibrariesCheckTest extends AbstractStaticCheckT
 
     @Test
     public void shouldNotLogBundleIsValid() throws Exception {
-        final String VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES = MAIN_DIRECTORY + File.separator + "validBundle";
         String[] warningMessages = CommonUtils.EMPTY_STRING_ARRAY;
-        verifyBuildProperties(getBuildPropertiesPath(VALID_BUNDLE_WITH_JAR_FILES_IN_BUILD_PROPERTIES), warningMessages);
+        verifyBuildProperties(getBuildPropertiesPath("validBundle"), warningMessages);
     }
 
     @Test
     public void shouldLogWhenThereAreJarFilesOutsideOfLibFolder() throws Exception {
-        final String BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER = MAIN_DIRECTORY + File.separator
-                + "bundleWithJarFilesOutsideOfLib";
-        final String JAR_PATH = getPath(BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER);
+        final String JAR_PATH = getPath("bundleWithJarFilesOutsideOfLib");
         String message = "There is a jar outside of the lib folder %s" + File.separator + "%s";
 
         String[] warningMessages = generateExpectedMessages(0, String.format(message, JAR_PATH, "test3.jar"));
-        verifyBuildProperties(getBuildPropertiesPath(BUNDLE_WITH_JAR_FILES_OUTSIDE_OF_LIB_FOLDER), warningMessages);
+        verifyBuildProperties(getBuildPropertiesPath("bundleWithJarFilesOutsideOfLib"), warningMessages);
     }
 
     private void verifyBuildProperties(String filePath, String[] warningMessages) throws Exception {

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
@@ -18,7 +18,6 @@ import org.openhab.tools.analysis.checkstyle.OverridingParentPomConfigurationChe
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -28,20 +27,16 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class OverridingParentPomConfigurationCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY_NAME = "overridingParentPomConfigurationCheckTest";
-
     private static DefaultConfiguration config;
 
     @BeforeClass
     public static void createConfiguration() {
-        config = createCheckConfig(OverridingParentPomConfigurationCheck.class);
+        config = createModuleConfig(OverridingParentPomConfigurationCheck.class);
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/overridingParentPomConfigurationCheckTest";
     }
 
     @Test
@@ -66,8 +61,7 @@ public class OverridingParentPomConfigurationCheckTest extends AbstractStaticChe
     }
 
     private void verifyPom(String pomDirectoryName, String[] expectedMessages) throws Exception {
-        String pomXmlAbsolutePath = getPath(
-                TEST_DIRECTORY_NAME + File.separator + pomDirectoryName + File.separator + POM_XML_FILE_NAME);
+        String pomXmlAbsolutePath = getPath(pomDirectoryName + File.separator + POM_XML_FILE_NAME);
         verify(config, pomXmlAbsolutePath, expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
@@ -18,7 +18,6 @@ import org.openhab.tools.analysis.checkstyle.PackageExportsNameCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -33,15 +32,19 @@ public class PackageExportsNameCheckTest extends AbstractStaticCheckTest {
             + " should be marked as \"internal\" if it is not exported.";
 
     private static final String MANIFEST_REALTIVE_PATH = META_INF_DIRECTORY_NAME + File.separator + MANIFEST_FILE_NAME;
-    private static final String TEST_DIRECTORY = "packageExportsNameCheckTest";
 
     private static DefaultConfiguration configuration;
 
     @BeforeClass
     public static void createConfiguration() {
-        configuration = createCheckConfig(PackageExportsNameCheck.class);
+        configuration = createModuleConfig(PackageExportsNameCheck.class);
         configuration.addAttribute("sourceDirectories", "src/main/java");
         configuration.addAttribute("excludedPackages", ".*.internal.*");
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/packageExportsNameCheckTest";
     }
 
     @Test
@@ -76,20 +79,12 @@ public class PackageExportsNameCheckTest extends AbstractStaticCheckTest {
         verifyWarningMessages("excluded_packages", expectedMessages);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
-    }
-
     private void verifyNoWarningMessages(String directory) throws Exception {
         verifyWarningMessages(directory, CommonUtils.EMPTY_STRING_ARRAY);
     }
 
     private void verifyWarningMessages(String directory, String[] messages) throws Exception {
-        String manifestFilePath = getPath(
-                TEST_DIRECTORY + File.separator + directory + File.separator + MANIFEST_REALTIVE_PATH);
+        String manifestFilePath = getPath(directory + File.separator + MANIFEST_REALTIVE_PATH);
 
         verify(configuration, manifestFilePath, messages);
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
@@ -8,7 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
 import java.text.MessageFormat;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -18,7 +17,6 @@ import org.openhab.tools.analysis.checkstyle.ParameterizedRegexpHeaderCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 
 /**
  * Tests for {@link ParameterizedRegexpHeaderCheck}
@@ -29,7 +27,6 @@ public class ParameterizedRegexpHeaderCheckTest extends AbstractStaticCheckTest 
     private static final String MSG_MISMATCH = "Header line doesn''t match pattern {0}";
     private static final String MSG_MISSING = "Header is missing";
 
-    private static final String TEST_DIRECOTRY = "parameterizedRegexpHeaderCheckTest";
     private static final String TEST_JAVADOC_HEADER_PATTERN = "^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} by the respective copyright holders\\.$\\n^ \\*$";
     private static final String TEST_JAVA_COMMENT_HEADER_PATTERN = "^//$\\n^// Copyright \\(c\\) {0}-{1} by the respective copyright holders\\.$\\n^//$";
     private static final String TEST_XML_HEADER_PATTERN = "^<!-- Copyright \\(c\\) {0}-{1} by the respective copyright holders\\. -->$";
@@ -42,10 +39,8 @@ public class ParameterizedRegexpHeaderCheckTest extends AbstractStaticCheckTest 
     }
 
     @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
+    protected String getPackageLocation() {
+        return "checkstyle/parameterizedRegexpHeaderCheckTest";
     }
 
     @Test
@@ -89,12 +84,12 @@ public class ParameterizedRegexpHeaderCheckTest extends AbstractStaticCheckTest 
     }
 
     private void verifyJavaFile(String name, String[] messages) throws Exception {
-        String path = getPath(TEST_DIRECOTRY + File.separator + name);
+        String path = getPath(name);
         verify(createChecker(config), path, messages);
     }
 
     private DefaultConfiguration createTestConfiguration(String headerPattern, String values, String headerFormat) {
-        DefaultConfiguration configuration = createCheckConfig(ParameterizedRegexpHeaderCheck.class);
+        DefaultConfiguration configuration = createModuleConfig(ParameterizedRegexpHeaderCheck.class);
         if (headerPattern != null) {
             configuration.addAttribute("header", headerPattern);
         }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -22,7 +22,6 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 import org.openhab.tools.analysis.checkstyle.api.CheckConstants;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -33,7 +32,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  * @author Velin Yordanov - Added new tests
  */
 public class PomXmlCheckTest extends AbstractStaticCheckTest {
-    private static final String POM_XML_CHECK_TEST_DIRECTORY_NAME = "pomXmlCheckTest";
     private static final String VERSION_REGULAR_EXPRESSION = "^\\d+\\.\\d+\\.\\d+";
 
     private static final String MISSING_VERSION_MSG = "Missing /project/version in the pom.xml file.";
@@ -51,9 +49,14 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
 
     @BeforeClass
     public static void setUpClass() {
-        config = createCheckConfig(PomXmlCheck.class);
+        config = createModuleConfig(PomXmlCheck.class);
         config.addAttribute("pomVersionRegularExpression", VERSION_REGULAR_EXPRESSION);
         config.addAttribute("manifestVersionRegularExpression", MANIFEST_REGEX);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/pomXmlCheckTest";
     }
 
     @Test
@@ -98,7 +101,7 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void testMasterPom() throws Exception {
-        String testFileAbsolutePath = getPath(POM_XML_CHECK_TEST_DIRECTORY_NAME + "/pom.xml");
+        String testFileAbsolutePath = getPath("pom.xml");
         verify(createChecker(config), testFileAbsolutePath, ArrayUtils.EMPTY_STRING_ARRAY);
     }
 
@@ -115,13 +118,6 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testDifferentPomVersion() throws Exception {
         verifyPomXmlFile("different_version_pom_directory", 9, WRONG_VERSION_MSG);
-    }
-
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
     }
 
     private void verifyPomXmlFile(String testDirectoryName, int expectedLine, String expectedMessage) throws Exception {
@@ -153,7 +149,7 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
     }
 
     private File getTestDirectory(String testDirectoryName) throws Exception {
-        String testDirectoryAbsolutePath = getPath(POM_XML_CHECK_TEST_DIRECTORY_NAME + "/" + testDirectoryName);
+        String testDirectoryAbsolutePath = getPath(testDirectoryName);
         return new File(testDirectoryAbsolutePath);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -16,7 +16,6 @@ import org.openhab.tools.analysis.checkstyle.RequireBundleCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -35,10 +34,15 @@ public class RequireBundleCheckTest extends AbstractStaticCheckTest {
 
     @BeforeClass
     public static void setUpClass() {
-        config = createCheckConfig(RequireBundleCheck.class);
+        config = createModuleConfig(RequireBundleCheck.class);
 
         String allowedRequireBundles = String.format("%s,%s,%s", "org.junit", "org.hamcrest", "org.mockito");
         config.addAttribute("allowedRequireBundles", allowedRequireBundles);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/requireBundleCheckTest";
     }
 
     @Test
@@ -66,18 +70,9 @@ public class RequireBundleCheckTest extends AbstractStaticCheckTest {
         verifyManifest("invalid_test_manifest_directory", "INVALID_TEST_MANIFEST.MF", 13, REQUIRE_BUNDLE_TEST_USED_MSG);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
-    }
-
     private void verifyManifest(String testDirectoryName, String testFileName, int expectedLine, String expectedMessage)
             throws Exception {
-        String requireBundleCheckTestDirectory = "requireBundleCheckTest/";
-        String manifestRelativePath = requireBundleCheckTestDirectory + File.separator + testDirectoryName
-                + File.separator + testFileName;
+        String manifestRelativePath = testDirectoryName + File.separator + testFileName;
         String manifestAbsolutePath = getPath(manifestRelativePath);
 
         String[] expectedMessages = null;

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
@@ -24,7 +24,6 @@ import org.openhab.tools.analysis.checkstyle.RequiredFilesCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -36,14 +35,13 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 public class RequiredFilesCheckTest extends AbstractStaticCheckTest {
     private static final String MANIFEST_RELATIVE_PATH_NAME = META_INF_DIRECTORY_NAME + File.separator
             + MANIFEST_FILE_NAME;
-    private static final String TEST_DIRECTORY_NAME = "requiredFilesCheckTest";
     private static final String MISSING_FILE_MSG = "Missing %s file.";
 
     private static DefaultConfiguration config;
 
     @BeforeClass
     public static void setUpClass() {
-        config = createCheckConfig(RequiredFilesCheck.class);
+        config = createModuleConfig(RequiredFilesCheck.class);
 
         String extenstionsPropertyValue = String.format("%s,%s,%s,%s,%s", HTML_EXTENSION, PROPERTIES_EXTENSION,
                 XML_EXTENSION, MANIFEST_EXTENSION, MARKDONW_EXTENSION);
@@ -52,6 +50,11 @@ public class RequiredFilesCheckTest extends AbstractStaticCheckTest {
         String requiredFilesPropertyValue = String.format("%s,%s,%s,%s,%s", ABOUT_HTML_FILE_NAME,
                 BUILD_PROPERTIES_FILE_NAME, POM_XML_FILE_NAME, MANIFEST_RELATIVE_PATH_NAME, README_MD_FILE_NAME);
         config.addAttribute("requiredFiles", requiredFilesPropertyValue);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/requiredFilesCheckTest";
     }
 
     @Test
@@ -124,16 +127,9 @@ public class RequiredFilesCheckTest extends AbstractStaticCheckTest {
         verify(createChecker(config), testFiles, expectedViolations);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration defaultConfiguration = new DefaultConfiguration("root");
-        defaultConfiguration.addChild(config);
-        return defaultConfiguration;
-    }
-
     private void verifyDirectory(String testDirectoryName, String fileName, String expectedMessage) throws Exception {
         File[] testFiles = getFilesForDirectory(testDirectoryName);
-        String testDirectoryAbsolutePath = getDirectoryAbsolutePath(testDirectoryName);
+        String testDirectoryAbsolutePath = getPath(testDirectoryName);
         String messageFilePath = testDirectoryAbsolutePath + File.separator + fileName;
 
         String[] expectedMessages;
@@ -152,15 +148,9 @@ public class RequiredFilesCheckTest extends AbstractStaticCheckTest {
     }
 
     private File[] getFilesForDirectory(String directoryName) throws IOException {
-        String directoryAbsolutePath = getDirectoryAbsolutePath(directoryName);
+        String directoryAbsolutePath = getPath(directoryName);
         File directory = new File(directoryAbsolutePath);
         File[] files = listFilesForDirectory(directory, new ArrayList<File>());
         return files;
-    }
-
-    private String getDirectoryAbsolutePath(String directoryName) throws IOException {
-        String directoryRelativePath = TEST_DIRECTORY_NAME + File.separator + directoryName;
-        String directoryAbsolutePath = getPath(directoryRelativePath);
-        return directoryAbsolutePath;
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ServiceComponentManifestCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ServiceComponentManifestCheckTest.java
@@ -20,7 +20,6 @@ import org.openhab.tools.analysis.checkstyle.ServiceComponentManifestCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -34,7 +33,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class ServiceComponentManifestCheckTest extends AbstractStaticCheckTest {
-    private static final String CHECK_TEST_DIRECTORY = "serviceComponentManifestCheckTest";
     private static final String MANIFEST_RELATIVE_PATH = META_INF_DIRECTORY_NAME + File.separator + MANIFEST_FILE_NAME;
 
     private static final String BEST_APPROACH_MESSAGE = "A good approach is to use OSGI-INF/*.xml "
@@ -56,7 +54,12 @@ public class ServiceComponentManifestCheckTest extends AbstractStaticCheckTest {
 
     @BeforeClass
     public static void createConfiguration() {
-        config = createCheckConfig(ServiceComponentManifestCheck.class);
+        config = createModuleConfig(ServiceComponentManifestCheck.class);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/serviceComponentManifestCheckTest";
     }
 
     @Test
@@ -203,13 +206,6 @@ public class ServiceComponentManifestCheckTest extends AbstractStaticCheckTest {
         verifyBuildProperties("missing_all_services_in_build_properties", expectedMessages);
     }
 
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = new DefaultConfiguration("root");
-        configParent.addChild(config);
-        return configParent;
-    }
-
     private void verifyServiceComponentHeader(String testDirectoryName, String[] expectedMessages) throws Exception {
         verify(MANIFEST_RELATIVE_PATH, testDirectoryName, expectedMessages);
     }
@@ -219,8 +215,7 @@ public class ServiceComponentManifestCheckTest extends AbstractStaticCheckTest {
     }
 
     private void verify(String filePath, String testDirectoryName, String[] expectedMessages) throws Exception {
-        String testDirectoryPath = getPath(CHECK_TEST_DIRECTORY + File.separator + testDirectoryName);
-        File testDirectory = new File(testDirectoryPath);
+        File testDirectory = new File(getPath(testDirectoryName));
         String testFilePath = testDirectory.getPath() + File.separator + filePath;
         // All files are listed recursively
         File[] testFiles = FileUtils.listFiles(testDirectory, null, true).toArray(new File[] {});

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <mockito.version>2.8.47</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
     <pmd.version>5.8.1</pmd.version>
-    <checkstyle.version>8.1</checkstyle.version>
+    <checkstyle.version>8.9</checkstyle.version>
     <spotbugs.version>3.1.2</spotbugs.version>
     <maven.plugin.api.version>3.1.1</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.5</maven.plugin.annotations.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -115,7 +115,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "8.1"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "8.9"));
         checkstylePlugins.forEach(logDependency());
 
         Xpp3Dom config = configuration(element("sourceDirectory", mavenProject.getBasedir().toString()));


### PR DESCRIPTION
Update the checkstyle version from 8.1 to 8.9.

This should provide a solution for #294 and #225.

Looking at the [release notes](http://checkstyle.sourceforge.net/releasenotes.html#Release_8.9) these API-breaking changes that could potentially affect us are resolved :

* *Disallowing user to use incomplete fully qualified Check names in config file.*
We are using just the check name, not the fully qualified name, so this check should not affect us.
e.g: We use `NewlineAtEndOfFile`  in our configuration file and currently both `NewlineAtEndOfFile` and `com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck` are allowed. 
What is no longer allowed is `com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFile`

* *BaseCheckTestSupport is deprecated.*
All test classes are refactored to compile and work as intended.

* *Split TreeWalker to TreeWalker and JavaParser.*
JavaParser is a utility class with static methods that contains methods that were previously in the TreeWalker class. We do not use these methods directly.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>