### PR TITLE
change pmd version to 6.2.0

### DIFF
--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
@@ -23,7 +23,7 @@ public class ClasspathTest extends SimpleAggregatorTst {
     // How to implement PMD rule test - https://pmd.github.io/pmd-5.4.1/customizing/rule-guidelines.html
     @Override
     @Before
-    protected void setUp() {
+    public void setUp() {
         addRule("src/test/resources/pmd/ruleset/classpath.xml", "AvoidMavenPomderivedInClasspath");
     }
 }

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
@@ -22,7 +22,7 @@ public class PomTest extends SimpleAggregatorTst {
 
     @Override
     @Before
-    protected void setUp() {
+    public void setUp() {
         addRule("src/test/resources/pmd/ruleset/pom.xml", "AvoidOverridingParentPomConfiguration");
     }
 }

--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidMavenPomderivedInClasspath.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidMavenPomderivedInClasspath.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test-data>
+<test-data  xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
   <test-code>
     <description>Maven pomderived in .classpath</description>
     <expected-problems>1</expected-problems>

--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidOverridingParentPomConfiguration.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidOverridingParentPomConfiguration.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test-data>
+<test-data  xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
   <test-code>
     <description>Override parent pom configuration</description>
     <expected-problems>1</expected-problems>

--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/WhileLoopsMustUseBracesRule.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/WhileLoopsMustUseBracesRule.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test-data>
+<test-data  xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
   <test-code>
     <description>While loop  must use braces</description>
     <expected-problems>1</expected-problems>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <commons.lang.version>2.6</commons.lang.version>
     <mockito.version>2.8.47</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
-    <pmd.version>5.8.1</pmd.version>
+    <pmd.version>6.2.0</pmd.version>
     <checkstyle.version>8.9</checkstyle.version>
     <spotbugs.version>3.1.2</spotbugs.version>
     <maven.plugin.api.version>3.1.1</maven.plugin.api.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -55,7 +55,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.8")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.9.0")
     private String mavenPmdVersion;
 
     /**
@@ -64,7 +64,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "5.8.1";
+    private static final String PMD_VERSION = "6.2.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */

--- a/sat-plugin/src/main/resources/report/prepare_pmd.xslt
+++ b/sat-plugin/src/main/resources/report/prepare_pmd.xslt
@@ -36,29 +36,30 @@
  *
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:pmdns="http://pmd.sourceforge.net/report/2.0.0"
 	xmlns:functx="http://www.functx.com" version="2.0">
 
 	<xsl:output method="xml" indent="yes" encoding="ISO-8859-1" />
 
 	<xsl:template match="/">
 		<sca>
-			<xsl:for-each select="//pmd">
+			<xsl:for-each select="//pmdns:pmd">
 				<xsl:apply-templates />
 			</xsl:for-each>
 		</sca>
 	</xsl:template>
 
- 	<xsl:template match="file">
-		 <xsl:variable name="package_tmp" select="./violation/@package" />
+ 	<xsl:template match="pmdns:file">
+		 <xsl:variable name="package_tmp" select="./pmdns:violation/@package" />
 	     <xsl:variable name="package" select="distinct-values($package_tmp)" />	     
-	     <xsl:variable name="class_tmp" select="./violation/@class" />
+	     <xsl:variable name="class_tmp" select="./pmdns:violation/@class" />
 	     <xsl:variable name="class" select="distinct-values($class_tmp)" />
 		<file name="{$package}.{$class}.java">
 			<xsl:apply-templates select="node()" />
 		</file>
 	</xsl:template>
 
-	<xsl:template match="violation">
+	<xsl:template match="pmdns:violation">
 		<message>
 			<xsl:attribute name="tool">pmd</xsl:attribute>
 			<xsl:attribute name="line"><xsl:value-of select="@beginline" /></xsl:attribute>

--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -4,107 +4,104 @@
 
   <description>Default set of PMD rules used for checking all bundles Eclipse SmartHome project</description>
 
-  <rule ref="rulesets/java/empty.xml/EmptyIfStmt">
-    <!-- See http://pmd.sourceforge.net/pmd-5.0.0/rules/java/empty.html for all below -->
+  <rule ref="category/java/errorprone.xml/EmptyIfStmt">
+    <!-- See https://pmd.github.io/pmd-6.2.0/pmd_rules_java_errorprone.html for all below -->
     <!-- Priorities range in value from 1 to 5, with 5 being the lowest priority -->
     <!--  We will use only priority 1,2 and 3 so the results of PMD can be comparable with the results of the other tools -->
     
     <!-- See http://pmd.github.io/pmd-5.0.1/apidocs/net/sourceforge/pmd/RulePriority.html -->
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptyWhileStmt">
+  <rule ref="category/java/errorprone.xml/EmptyWhileStmt">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptyTryBlock">
+  <rule ref="category/java/errorprone.xml/EmptyTryBlock">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptyFinallyBlock">
+  <rule ref="category/java/errorprone.xml/EmptyFinallyBlock">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptySwitchStatements">
+  <rule ref="category/java/errorprone.xml/EmptySwitchStatements">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptySynchronizedBlock">
+  <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock">
     <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/empty.xml/EmptyStaticInitializer">
+  <rule ref="category/java/errorprone.xml/EmptyInitializer">
+    <priority>3</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/MisplacedNullCheck">
+    <priority>1</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/BrokenNullCheck">
+    <priority>1</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/JumbledIncrementer">
+    <priority>2</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray">
+    <priority>2</priority>
+  </rule>  
+  <rule ref="category/java/errorprone.xml/MoreThanOneLogger">
+    <priority>3</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingNPE">
+    <priority>2</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable">
+    <priority>2</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally">
+    <priority>2</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/EqualsNull">
+    <priority>1</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/InstantiationToGetClass">
+    <priority>3</priority>
+  </rule>
+  <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause">
+    <priority>2</priority>
+  </rule>
+   <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals">
     <priority>3</priority>
   </rule>
   
-  <!-- See  http://pmd.sourceforge.net/pmd-5.0.0/rules/java/basic.html -->
-  <rule ref="rulesets/java/basic.xml/MisplacedNullCheck">
-    <priority>1</priority>
-  </rule>
-  <rule ref="rulesets/java/basic.xml/BrokenNullCheck">
-    <priority>1</priority>
-  </rule>
-  <rule ref="rulesets/java/basic.xml/JumbledIncrementer">
+  <!-- See https://pmd.github.io/pmd-6.2.0/pmd_rules_java_multithreading.html -->
+  <rule ref="category/java/multithreading.xml/DontCallThreadRun">
     <priority>2</priority>
   </rule>
-  <rule ref="rulesets/java/basic.xml/ClassCastExceptionWithToArray">
-    <priority>2</priority>
+  <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton">
+    <priority>3</priority>
   </rule>
-  <rule ref="rulesets/java/basic.xml/DontCallThreadRun">
+  <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter">
+    <priority>3</priority>
+  </rule>
+  
+    <!-- See https://pmd.github.io/pmd-6.2.0/pmd_rules_java_bestpractices.html -->
+  <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
+    <priority>1</priority>
+  </rule>
+  <rule ref="category/java/bestpractices.xml/SystemPrintln">
     <priority>2</priority>
   </rule>
   
-  <!-- See http://pmd.sourceforge.net/pmd-5.0.0/rules/java/logging-java.html -->
-  <rule ref="rulesets/java/logging-java.xml/MoreThanOneLogger">
-    <priority>3</priority>
+  <!-- See https://pmd.github.io/pmd-6.2.0/pmd_rules_java_design.html -->
+  <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes">
+    <priority>2</priority>
   </rule>
-  <rule ref="rulesets/java/logging-java.xml/AvoidPrintStackTrace">
+  <rule ref="category/java/design.xml/AvoidThrowingNullPointerException">
     <priority>1</priority>
   </rule>
-  <rule ref="rulesets/java/logging-java.xml/SystemPrintln">
-    <priority>2</priority>
+  <rule ref="category/java/design.xml/DoNotExtendJavaLangError">
+    <priority>1</priority>
+  </rule>
+  <rule ref="category/java/design.xml/SimplifyBooleanExpressions">
+    <priority>3</priority>
   </rule>
   
-  <!-- See http://pmd.sourceforge.net/pmd-5.0.0/rules/java/strictexception.html -->
-  <rule ref="rulesets/java/strictexception.xml/AvoidCatchingNPE">
-    <priority>2</priority>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/AvoidCatchingThrowable">
-    <priority>2</priority>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingRawExceptionTypes">
-    <priority>2</priority>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/AvoidThrowingNullPointerException">
-    <priority>1</priority>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/DoNotThrowExceptionInFinally">
-    <priority>2</priority>
-  </rule>
-  <rule ref="rulesets/java/strictexception.xml/DoNotExtendJavaLangError">
-    <priority>1</priority>
-  </rule>
-  
-  <!-- See http://pmd.sourceforge.net/pmd-5.0.0/rules/java/design.html -->
-  <rule ref="rulesets/java/design.xml/EqualsNull">
-    <priority>1</priority>
-  </rule>
-  <rule ref="rulesets/java/design.xml/InstantiationToGetClass">
-    <priority>3</priority>
-  </rule>
-  <rule ref="rulesets/java/design.xml/AvoidInstanceofChecksInCatchClause">
-    <priority>2</priority>
-  </rule>
-   <rule ref="rulesets/java/design.xml/CompareObjectsWithEquals">
-    <priority>3</priority>
-  </rule>
-  <rule ref="rulesets/java/design.xml/NonThreadSafeSingleton">
-    <priority>3</priority>
-  </rule>
-  <rule ref="rulesets/java/design.xml/UnsynchronizedStaticDateFormatter">
-    <priority>3</priority>
-  </rule>
-  <rule ref="rulesets/java/design.xml/SimplifyBooleanExpressions">
-    <priority>3</priority>
-  </rule>
-
-  
-  <!-- See http://pmd.sourceforge.net/pmd-5.0.0/rules/java/optimizations.html -->
-  <rule ref="rulesets/java/optimizations.xml/AvoidArrayLoops">
+  <!-- See https://pmd.github.io/pmd-6.2.0/pmd_rules_java_performance.html -->
+  <rule ref="category/java/performance.xml/AvoidArrayLoops">
     <priority>3</priority>
   </rule>
 </ruleset>

--- a/sat-plugin/src/test/resources/report/pmd.xml
+++ b/sat-plugin/src/test/resources/report/pmd.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Resource used in the test in order an .html report to be build. Does not point to real files in the file system. -->
-<pmd version="4.2.5" timestamp="2010-07-23T20:34:59.300">
+<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd"
+    version="4.2.5" timestamp="2010-07-23T20:34:59.300">
 <file name="C:\Workspace\default_ant\src\org\sprunck\bee\Bee.java">
 <violation beginline="19" endline="19" begincolumn="13" endcolumn="20" rule="UselessOperationOnImmutable" ruleset="Basic Rules" package="org.sprunck.bee" class="Bee" method="toString" externalInfoUrl="http://pmd.sourceforge.net/rules/basic.html#UselessOperationOnImmutable" priority="3">
 An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself


### PR DESCRIPTION
Update pmd version to 6.2.0.

I ran the builds and there is no regression in the code analysis for esh, openhab-core and openhab2-addons repos using pmd 6.2 version.

Fixes #257.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>