### PR TITLE
create a check to warn if there are trailing Whitespaces

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/TrailingWhitespacesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/TrailingWhitespacesCheck.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineCheck;
+
+/**
+ * @author Lyubomir Papazov - Initial contribution
+ *
+ */
+public class TrailingWhitespacesCheck extends RegexpSinglelineCheck {
+    public static final String TRAILING_WHITESPACE_MESSAGE = "Code lines should not end with trailing whitespace";
+    private static final String REGEXP_TRAILING_WHITESPACES = "\\s+$";
+
+    public TrailingWhitespacesCheck() {
+        setMessage(TRAILING_WHITESPACE_MESSAGE);
+        setFormat(REGEXP_TRAILING_WHITESPACES);
+    }
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/TrailingWhitespacesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/TrailingWhitespacesCheckTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.TrailingWhitespacesCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link TrailingWhitespacesCheck}
+ * 
+ * @author Lyubomir Papazov - Initial contribution
+ *
+ */
+public class TrailingWhitespacesCheckTest extends AbstractStaticCheckTest {
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/trailingWhitespacesCheckTest";
+    }
+
+    @Test
+    public void testOneTrailingWhitespace() throws Exception {
+        int lineNumber = 3;
+        String[] expectedMessages = generateExpectedMessages(lineNumber,
+                TrailingWhitespacesCheck.TRAILING_WHITESPACE_MESSAGE);
+        verify(createModuleConfig(TrailingWhitespacesCheck.class), getPath("OneTrailingWhitespace.java"),
+                expectedMessages);
+    }
+
+    @Test
+    public void testMultipleTrailingWhitespaces() throws Exception {
+        String[] expectedMessages = generateExpectedMessages(3, TrailingWhitespacesCheck.TRAILING_WHITESPACE_MESSAGE, 4,
+                TrailingWhitespacesCheck.TRAILING_WHITESPACE_MESSAGE);
+        verify(createModuleConfig(TrailingWhitespacesCheck.class), getPath("MultipleTrailingWhitespaces.java"),
+                expectedMessages);
+    }
+
+    @Test
+    public void testNoTrailingWhitespaces() throws Exception {
+        String[] expectedMessages =  CommonUtils.EMPTY_STRING_ARRAY;
+        verify(createModuleConfig(TrailingWhitespacesCheck.class), getPath("NoTrailingWhitespaces.java"),
+                expectedMessages);
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/MultipleTrailingWhitespaces.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/MultipleTrailingWhitespaces.java
@@ -1,0 +1,6 @@
+public clas MultipleTrailingWhitespaces {
+    private void testMethod() {
+        //Trailing whitespace after comment 
+        String trailingWhitespaceAfterCode; 
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/NoTrailingWhitespaces.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/NoTrailingWhitespaces.java
@@ -1,0 +1,5 @@
+public class NoTrailingWhitespaces {
+    private void noTrailingWhitespacesMethod() {
+        return;
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/OneTrailingWhitespace.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/trailingWhitespacesCheckTest/OneTrailingWhitespace.java
@@ -1,0 +1,5 @@
+public class OneTrailingWhitespace {
+    private void someMethod() {
+        return; 
+    }
+}

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -104,13 +104,17 @@
   	<property name="severity" value="warning" />
   </module>
 
+  <module name="org.openhab.tools.analysis.checkstyle.TrailingWhitespacesCheck">
+    <property name="severity" value="warning" />
+  </module>
+
   <module name="org.openhab.tools.analysis.checkstyle.RequiredFilesCheck">
      <property name="severity" value="error" />
      <property name="extensions" value="${checkstyle.requiredFilesCheck.extensions}" default="html,properties,xml,MF" />
      <!-- Relative path to the root directory of the module-->
      <property name="requiredFiles" value="${checkstyle.requiredFilesCheck.files}" default="about.html,build.properties,pom.xml,META-INF/MANIFEST.MF" />
   </module>
-   
+
   <module name="org.openhab.tools.analysis.checkstyle.BuildPropertiesCheck">
     <property name="severity" value="warning" />
     <!-- Other bin.includes values will be checked from a specific Checks (e.g.ServiceComponentManifestCheck) -->


### PR DESCRIPTION
This PR fixes #272.

Currently, it's not possible to create tests because of #294.

Once #296 is merged tests could be created.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>