### PR TITLE
fix compilation Errors

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestLineLengthCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestLineLengthCheckTest.java
@@ -16,8 +16,6 @@ import org.openhab.tools.analysis.checkstyle.ManifestLineLengthCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-import com.puppycrawl.tools.checkstyle.TreeWalker;
-import com.puppycrawl.tools.checkstyle.api.Configuration;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
 
 /**
@@ -27,7 +25,6 @@ import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
  *
  */
 public class ManifestLineLengthCheckTest extends AbstractStaticCheckTest {
-    private static final String TEST_DIRECTORY_NAME = "manifestLineLengthCheck";
     private static final byte MAX_LINE_SIZE = 72;
     private static final String LOG_MESSAGE = "No line may be longer than " + MAX_LINE_SIZE + " bytes (not characters), in its UTF8-encoded form. If a value would make the initial line longer than this, it should be continued on extra lines (each starting with a single SPACE).";
 
@@ -35,16 +32,9 @@ public class ManifestLineLengthCheckTest extends AbstractStaticCheckTest {
 
     @BeforeClass
     public static void setUp() {
-        configuration = createCheckConfig(ManifestLineLengthCheck.class);
+        configuration = createModuleConfig(ManifestLineLengthCheck.class);
     }
-    
-    @Override
-    protected DefaultConfiguration createCheckerConfig(Configuration config) {
-        DefaultConfiguration configParent = createCheckConfig(TreeWalker.class);
-        configParent.addChild(config);
-        return configParent;
-    }
-    
+
     @Test
     public void shouldNotLogWhenALineDoesNotExceedMaximumBytes() throws Exception {
         verifyManifest("CorrectManifest.MF", CommonUtils.EMPTY_STRING_ARRAY);
@@ -56,7 +46,12 @@ public class ManifestLineLengthCheckTest extends AbstractStaticCheckTest {
     }
     
     private void verifyManifest(String testFileName, String[] expectedMessages) throws Exception {
-        String absolutePathToTestFile = getPath(TEST_DIRECTORY_NAME + File.separator + testFileName);
+        String absolutePathToTestFile = getPath(testFileName);
         verify(configuration, absolutePathToTestFile, expectedMessages);
+    }
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/manifestLineLengthCheck";
     }
 }


### PR DESCRIPTION
Fix compilation errors which were caused by changing checkstyle version to 8.9.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>
