### PR TITLE
Added check that verifies that there are no forbidden packages in use.

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CheckUtils;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * A check that verifies that there are no forbidden packages in use.
+ * 
+ * @author Velin Yordanov - initial contribution
+ *
+ */
+public class ForbiddenPackageUsageCheck extends AbstractCheck {
+    private static final String MESSAGE = "The package %s should not be used.";
+    private Collection<String> forbiddenPackages;
+    private Collection<String> exceptions;
+    private Map<String, Integer> importsToLineNumbers = new HashMap<>();
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] { TokenTypes.IMPORT };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtils.EMPTY_INT_ARRAY;
+    }
+
+    /**
+     * Sets a configuration property that sets all the packages that need to be
+     * avoided.
+     * 
+     * @param value
+     *            The value of the forbiddenPackages array that we want to set
+     */
+    public void setForbiddenPackages(String[] value) {
+        forbiddenPackages = Arrays.asList(value);
+    }
+
+    /**
+     * Sets a configuration property that sets exceptions to the forbidden packages.
+     * Usable when we want to ban all subpackages but one.
+     * 
+     * @param value
+     *            - The value of the exceptions array that we want to set
+     */
+    public void setExceptions(String[] value) {
+        exceptions = Arrays.asList(value);
+    }
+
+    public void visitToken(DetailAST ast) {
+        importsToLineNumbers.put(CheckUtils.createFullType(ast).getText(), ast.getLineNo());
+    }
+
+    public void finishTree(DetailAST ast) {
+        importsToLineNumbers.entrySet().stream()
+                .filter(entry -> forbiddenPackages.stream().anyMatch(entry.getKey()::contains))
+                .filter(entry -> !exceptions.stream().anyMatch(entry.getKey()::contains))
+                .forEach(entry -> log(entry.getValue(), String.format(MESSAGE, entry.getKey())));
+    }
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+/**
+ * Tests for {@link ForbiddenPackageUsageCheck}
+ * 
+ * @author Velin Yordanov - initial contribution
+ *
+ */
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    private final static String MESSAGE = "The package %s should not be used.";
+    DefaultConfiguration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Before
+    public void setUp() {
+        config.addAttribute("forbiddenPackages", "com.google.common,com.something.something,org.something.asd");
+        config.addAttribute("exceptions", "com.google.common.utils");
+    }
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    @Test
+    public void shouldLogWhenAForbiddenPackageIsInUse() throws Exception {
+        verifyClass("file-with-forbidden-package.java", generateExpectedMessages(7,String.format(MESSAGE, "com.something.something")));
+    }
+    
+    @Test
+    public void shouldLogWhenThereAreMultipleForbiddenPackagesInUse() throws Exception {
+        String secondMessage = String.format(MESSAGE, "com.something.something");
+        String firstMessage = String.format(MESSAGE, "org.something.asd");
+        verifyClass("file-with-multiple-forbidden-packages.java", generateExpectedMessages(7,firstMessage,8,secondMessage));
+    }
+    
+    @Test
+    public void shouldLogWhenAForbiddenSubpackageIsUsed() throws Exception {
+        verifyClass("file-with-forbidden-subpackage.java", generateExpectedMessages(7,String.format(MESSAGE, "com.google.common.collect")));
+    }
+    
+    @Test
+    public void shouldNotLogWhenThePackageIsAddedToExceptions() throws Exception {
+        verifyClass("file-with-exception.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    @Test
+    public void shouldNotLogWhenTheSubpackageIsAddedToExceptions() throws Exception {
+        verifyClass("file-with-subpackage-with-exception.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    @Test
+    public void shouldLogOnlyThePackagesThatAreNotInExceptionsWhenMultiplePackagesAreUsed() throws Exception {
+        String secondMessage = String.format(MESSAGE, "com.something.something");
+        String firstMessage = String.format(MESSAGE, "org.something.asd");
+        String thirdMessage = String.format(MESSAGE, "com.google.common.collect");
+        verifyClass("file-with-multiple-packages.java", generateExpectedMessages(7,firstMessage,8,secondMessage,10,thirdMessage));
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-exception.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-exception.java
@@ -1,0 +1,30 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import com.google.common.utils;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-forbidden-package.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-forbidden-package.java
@@ -1,0 +1,30 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import com.something.something;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-forbidden-subpackage.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-forbidden-subpackage.java
@@ -1,0 +1,30 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import com.google.common.collect;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-multiple-forbidden-packages.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-multiple-forbidden-packages.java
@@ -1,0 +1,31 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import org.something.asd;
+import com.something.something;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-multiple-packages.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-multiple-packages.java
@@ -1,0 +1,33 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import org.something.asd;
+import com.something.something;
+import com.google.common.utils;
+import com.google.common.collect;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-subpackage-with-exception.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/file-with-subpackage-with-exception.java
@@ -1,0 +1,30 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+import com.google.common.utils.something;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/validFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ForbiddenPackageUsageCheckTest/validFile.java
@@ -1,0 +1,29 @@
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.Test;
+import org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck;
+import org.openhab.tools.analysis.checkstyle.InheritDocCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.api.Configuration;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtils;
+
+public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
+    Configuration config = createModuleConfig(ForbiddenPackageUsageCheck.class);
+    
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/ForbiddenPackageUsageCheckTest";
+    }
+    
+    @Test
+    public void shouldNotLogWhenThereIsNoForbiddenPackageUsage() throws Exception {
+        verifyClass("validFile.java", CommonUtils.EMPTY_STRING_ARRAY);
+    }
+    
+    private void verifyClass(String testFileName, String[] expectedMessages) throws Exception {
+        String absolutePathToTestFile = getPath(testFileName);
+        verify(config, absolutePathToTestFile, expectedMessages);
+    }
+
+}

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -196,7 +196,12 @@
       <property name="severity" value="warning" />
     </module>
     <module name="org.openhab.tools.analysis.checkstyle.InheritDocCheck">
+      <property name="severity" value="warning" />      
+    </module>
+    <module name="org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck">
       <property name="severity" value="warning" />
+      <property name="forbiddenPackages" value="${checkstyle.forbiddenPackageUsageCheck.forbiddenPackages}"/>
+      <property name="exceptions" value="${checkstyle.forbiddenPackageUsageCheck.exceptions}"/>
     </module>
     <module name="UnusedImports">
       <property name="processJavadoc" value="true"/>


### PR DESCRIPTION
See #297 
I made the check a bit more abstract and it works for all kinds of packages, not just guava.

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>