### PR TITLE
Enhanced the OnlyTabIndentationXmlCheck

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
@@ -25,26 +25,26 @@ import com.puppycrawl.tools.checkstyle.api.FileText;
  * @author Kristina Simova - Removed REGEX and changed the way we look for indentation
  *
  */
-public class OnlyTabIndentationInXmlFilesCheck extends AbstractStaticCheck {
+public class OnlyTabIndentationCheck extends AbstractStaticCheck {
 
     private static final String TAB_CHARACTER = "\t";
     private static final String WARNING_MESSAGE = "There were whitespace characters used for indentation. Please use tab characters instead";
     private boolean onlyShowFirstWarning;
 
-    public OnlyTabIndentationInXmlFilesCheck() {
-        setFileExtensions(XML_EXTENSION);
-    }
-
     public void setOnlyShowFirstWarning(Boolean showFirstExceptionOnly) {
         this.onlyShowFirstWarning = showFirstExceptionOnly;
+    }
+    
+    public void setFileTypes(String[] value) {
+        setFileExtensions(value);
     }
 
     @Override
     protected void processFiltered(File file, FileText fileText) {
-        processXmlTabIdentationCheck(fileText);
+        processTabIdentationCheck(fileText);
     }
 
-    private void processXmlTabIdentationCheck(FileText fileText) {
+    private void processTabIdentationCheck(FileText fileText) {
         for (int lineNumber = 0; lineNumber < fileText.size(); lineNumber++) {
             String line = fileText.get(lineNumber);
             // if line is empty and does not contain only tabs for indentation

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
@@ -12,7 +12,7 @@ import static com.puppycrawl.tools.checkstyle.utils.CommonUtils.EMPTY_STRING_ARR
 
 import org.junit.Before;
 import org.junit.Test;
-import org.openhab.tools.analysis.checkstyle.OnlyTabIndentationInXmlFilesCheck;
+import org.openhab.tools.analysis.checkstyle.OnlyTabIndentationCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
 
 import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
@@ -24,14 +24,15 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
  * @author Lyubomir Papazov - initial contribution
  * @author Kristina Simova - Added tests
  */
-public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTest {
+public class OnlyTabIndentationCheckTest extends AbstractStaticCheckTest {
 
     private static final String WHITESPACE_USAGE_WARNING = "There were whitespace characters used for indentation. Please use tab characters instead";
     private DefaultConfiguration config;
 
     @Before
     public void setUpClass() {
-        config = createModuleConfig(OnlyTabIndentationInXmlFilesCheck.class);
+        config = createModuleConfig(OnlyTabIndentationCheck.class);
+        config.addAttribute("fileTypes", "xml,json");
     }
 
     @Override
@@ -42,6 +43,17 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
     @Test
     public void testOneLineXmlFile() throws Exception {
         verifyXmlTabIdentation("WhiteSpacesNotUsedBeforeOpeningTags.xml", noMessagesExpected());
+    }
+    
+    @Test
+    public void testValidJson() throws Exception {
+        verifyTabIdentation("validJson.json", noMessagesExpected(), false);
+    }
+    
+    @Test
+    public void testBadlyFormattedJson() throws Exception {
+        String[] expectedMessages = generateExpectedMessages(7, WHITESPACE_USAGE_WARNING);
+        verifyTabIdentation("badlyFormattedJson.json", expectedMessages, false);
     }
 
     @Test
@@ -59,13 +71,13 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
     @Test
     public void testManyIncorrectLinesShowAllWarnings() throws Exception {
         String[] expectedMessages = generateExpectedMessages(5, WHITESPACE_USAGE_WARNING, 6, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines.xml", expectedMessages, false);
+        verifyTabIdentation("WhiteSpaceUsedBeforeOpeningTagInManyLines.xml", expectedMessages, false);
     }
 
     @Test
     public void testXmlWithEmptyLinesAndComments() throws Exception {
         String fileName = "BasicModuleHandlerFactory.xml";
-        verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
+        verifyTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
@@ -76,19 +88,19 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
                 WHITESPACE_USAGE_WARNING, 11, WHITESPACE_USAGE_WARNING, 13, WHITESPACE_USAGE_WARNING, 17,
                 WHITESPACE_USAGE_WARNING, 18, WHITESPACE_USAGE_WARNING, 19, WHITESPACE_USAGE_WARNING, 20,
                 WHITESPACE_USAGE_WARNING, 21, WHITESPACE_USAGE_WARNING, 22, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation(fileName, expectedMessages, false);
+        verifyTabIdentation(fileName, expectedMessages, false);
     }
 
     @Test
     public void testXmlWithOnlyTabsForIndentation() throws Exception {
         String fileName = "binding.xml";
-        verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
+        verifyTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
     public void testAnotherXmlWithOnlyTabsForIndentation() throws Exception {
         String fileName = "thing-types.xml";
-        verifyXmlTabIdentation(fileName, noMessagesExpected(), false);
+        verifyTabIdentation(fileName, noMessagesExpected(), false);
     }
 
     @Test
@@ -101,7 +113,7 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
                 WHITESPACE_USAGE_WARNING, 33, WHITESPACE_USAGE_WARNING, 39, WHITESPACE_USAGE_WARNING, 40,
                 WHITESPACE_USAGE_WARNING, 41, WHITESPACE_USAGE_WARNING, 42, WHITESPACE_USAGE_WARNING, 59,
                 WHITESPACE_USAGE_WARNING, 60, WHITESPACE_USAGE_WARNING, 61, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation(fileName, expectedMessages, false);
+        verifyTabIdentation(fileName, expectedMessages, false);
     }
 
     @Test
@@ -111,7 +123,7 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
                 12, WHITESPACE_USAGE_WARNING, 13, WHITESPACE_USAGE_WARNING, 15, WHITESPACE_USAGE_WARNING, 16,
                 WHITESPACE_USAGE_WARNING, 17, WHITESPACE_USAGE_WARNING, 18, WHITESPACE_USAGE_WARNING, 19,
                 WHITESPACE_USAGE_WARNING, 20, WHITESPACE_USAGE_WARNING, 22, WHITESPACE_USAGE_WARNING);
-        verifyXmlTabIdentation(fileName, expectedMessages, false);
+        verifyTabIdentation(fileName, expectedMessages, false);
     }
 
     private String[] noMessagesExpected() {
@@ -119,7 +131,7 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
         return expectedMessages;
     }
 
-    private void verifyXmlTabIdentation(String fileName, String[] expectedMessages, boolean onlyShowFirstWarning)
+    private void verifyTabIdentation(String fileName, String[] expectedMessages, boolean onlyShowFirstWarning)
             throws Exception {
         String testFileAbsolutePath = getPath(fileName);
         String messageFilePath = testFileAbsolutePath;
@@ -132,6 +144,6 @@ public class OnlyTabIndentationInXmlFilesCheckTest extends AbstractStaticCheckTe
     }
 
     private void verifyXmlTabIdentation(String fileName, String[] expectedMessages) throws Exception {
-        verifyXmlTabIdentation(fileName, expectedMessages, true);
+        verifyTabIdentation(fileName, expectedMessages, true);
     }
 }

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIndentationInXmlFilesCheck/badlyFormattedJson.json
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIndentationInXmlFilesCheck/badlyFormattedJson.json
@@ -1,0 +1,29 @@
+[
+	{
+		"uid": "JsonDemoRule",
+		"name": "DemoRule",
+		"triggers": [
+			{
+			    "id": "RuleTrigger",
+				"label": "Item State Change Trigger",
+				"description": "This triggers a rule if an items state changed",
+				"type": "ItemStateChangeTrigger",
+				"configuration": {
+					"itemName": "DemoSwitch"
+				}
+			}
+		],
+		"actions": [
+			{
+				"id": "RuleAction",
+				"label": "Post command to an item",
+				"description": "Posts commands on items",
+				"type": "ItemPostCommandAction",
+				"configuration": {
+					"itemName": "DemoDimmer",
+					"command": "ON"
+				}
+			}
+		]
+	}
+]

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIndentationInXmlFilesCheck/validJson.json
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/onlyTabIndentationInXmlFilesCheck/validJson.json
@@ -1,0 +1,53 @@
+[
+	{
+		"name": "ItemSampleRule",
+		"uid": "ItemSampleRule",
+		"tags": [
+			"sample",
+			"item",
+			"jsonTest",
+			"rule"
+		],
+		"configuration": {
+			
+		},
+		"description": "Sample Rule for items definition.",
+		"triggers": [
+			{
+				"id": "ItemStateChangeTriggerID",
+				"type": "core.GenericEventTrigger",
+				"configuration": {
+					"eventSource": "myMotionItem",
+					"eventTopic": "smarthome/items/*",
+					"eventTypes": "ItemStateEvent"
+				}
+			}
+		],
+		"actions": [
+			{
+				"id": "ItemPostCommandActionID",
+				"type": "core.ItemCommandAction",
+				"configuration": {
+					"itemName": "myLampItem",
+					"command": "ON"
+				}
+			}
+		]
+	},
+	{
+		"uid": "ItemSampleRuleWithReferences",
+		"name": "ItemSampleRuleWithReferences",
+		"templateUID": "TemplateSampleRuleWithReferences",
+		"tags": [
+			"sample",
+			"item",
+			"jsonTest",
+			"rule",
+			"references"
+		],
+		"configuration": {
+			"triggerItem": "myMotionItem",
+			"actionItem": "myLampItem"
+		}
+	}
+]

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -75,9 +75,10 @@
     <property name="severity" value="warning" />
   </module>
   
-  <module name="org.openhab.tools.analysis.checkstyle.OnlyTabIndentationInXmlFilesCheck">
+  <module name="org.openhab.tools.analysis.checkstyle.OnlyTabIndentationCheck">
     <property name="severity" value="error" />
     <property name="onlyShowFirstWarning" value="true" />
+    <property name="fileTypes" value="${checkstyle.onlyTabIndentationCheck.fileTypes}" default="xml,json"/>
   </module>
 
   <module name="org.openhab.tools.analysis.checkstyle.RequireBundleCheck">


### PR DESCRIPTION
Now it works for all kinds of files, added configuration property for file extensions to check.

Signed-off-by: VelinYordanov <velin.iordanov@gmail.com>