### PR TITLE
Create two more MOJOs that allow only changed modules to be analysed

### DIFF
--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/changes/FindChangedBundlesMojo.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/changes/FindChangedBundlesMojo.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.changes;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * A MOJO that opens a diff file containing only the names of the changed files
+ * and then finds the artifactId of the maven module that contains these files.
+ * The diff file is {@link #diffOutputFile} and should be created by the #{@link ScmDiffMojo}.
+ * This MOJO should be either executed after the #{@link ScmDiffMojo} in the same phase, or executed in a later phase. 
+ * On execution, {@link FindChangedBundlesMojo} creates affectedArtifactIds maven property
+ * that contains the comma separated artifactIds of modules in which there are changes.
+ *
+ * @author Lyubomir Papazov - Initial contribution
+ *
+ */
+@Mojo(name="find-changed-bundles")
+public class FindChangedBundlesMojo extends AbstractMojo {
+
+    private static final String ARTIFACT_ID_SEPARATOR = ",";
+    private static final String ARTIFACT_ID_XPATH = "/project/artifactId/child::text()";
+    public static final String AFFECTED_ARTIFACT_IDS_PROPERTY = "affectedArtifactIds";
+
+    /**
+     * The name of the diff file from which changed files should be read.
+     */
+    @Parameter(property = "diffOutputFile", defaultValue = ScmDiffMojo.DEFAULT_DIFF_OUTPUT_FILE)
+    protected String  diffOutputFile;
+
+    @Parameter(defaultValue = "${project}")
+    private MavenProject project;
+
+    private Set<String> pomsForChangedFiles;
+    private Log log;
+    private XPathExpression exprArtifactId;
+
+    public FindChangedBundlesMojo() {
+        log = getLog();
+        createArtifactIdXPathExpression();
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Path pathToDiffFile = Paths.get(project.getBasedir().getAbsolutePath(), diffOutputFile);
+        try {
+            Stream<String> stream = Files.lines(pathToDiffFile);
+            //For multiple changed files in the same module, findPomForFile method returns the same pom for each file.
+            //We are only interested in the distinct pom files.
+            pomsForChangedFiles = stream.map(path -> findPomForFile(path)).distinct().collect(Collectors.toSet());
+            stream.close();
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Error occurred while processing pom files, listed in %s", pathToDiffFile));
+        }
+
+        Stream<String >artifactIds = pomsForChangedFiles.stream().map(path -> new File(path)).map(f -> getArtifactIdFromFile(f));
+
+        String commaSeparatedArtifactIds = artifactIds.collect(Collectors.joining(ARTIFACT_ID_SEPARATOR));
+        project.getProperties().setProperty(AFFECTED_ARTIFACT_IDS_PROPERTY, commaSeparatedArtifactIds);
+    }
+
+    private void createArtifactIdXPathExpression() {
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        try {
+            exprArtifactId = xpath.compile(ARTIFACT_ID_XPATH);
+        } catch (XPathExpressionException e) {
+            throw new RuntimeException(String.format("Unable to compile the following XPath: %s", ARTIFACT_ID_XPATH), e);
+        }
+    }
+
+    private String getArtifactIdFromFile(File pomXmlFile) {
+        Document pomXmlDocument = null;
+
+        try (InputStream pomXmlFileStream = new FileInputStream(pomXmlFile)) {
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            pomXmlDocument = dBuilder.parse(pomXmlFileStream);
+        } catch (IOException | ParserConfigurationException | SAXException e) {
+            throw new RuntimeException(String.format("Unable to create document from the file %s", pomXmlFile.getPath()), e);
+        }
+
+        NodeList nodes = null;
+        try {
+            nodes = (NodeList) exprArtifactId.evaluate(pomXmlDocument, XPathConstants.NODESET);
+        } catch (XPathExpressionException e) {
+            log.error("Unable to find artifactId", e);
+        }
+        if (nodes == null || nodes.getLength() > 1) {
+            throw new RuntimeException("Exactly one artifactId should be discovered by the Xpath expression");
+        }
+        return nodes.item(0).getNodeValue();
+    }
+
+    private String findPomForFile(String relativePath) {
+        File changedFile = new File(relativePath);
+        String parentDir = changedFile.getAbsoluteFile().getParentFile().getAbsolutePath();
+        File pomFile = new File(parentDir, "pom.xml");
+        if (pomFile.exists()) {
+            return pomFile.getAbsolutePath();
+        } else {
+            return findPomForFile(parentDir);
+        }
+    }
+}
+

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/changes/ScmDiffMojo.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/changes/ScmDiffMojo.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.changes;
+
+import static org.twdata.maven.mojoexecutor.MojoExecutor.configuration;
+import static org.twdata.maven.mojoexecutor.MojoExecutor.element;
+
+import java.util.ArrayList;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.BuildPluginManager;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.twdata.maven.mojoexecutor.MojoExecutor;
+
+/**
+ * A MOJO that creates a file, containing the names of all changed files whithin the module,
+ * for every maven module. In order for the names of new files to be in the diff file, 
+ * this MOJO should be used after new files have been staged for commit.
+ * The name of the file is set by {@link #diffOutputFile}.
+ * The created diff files could be later processed by {@link FindChangedBundlesMojo}
+ *
+ * @author Lyubomir Papazov - Initial Contribution
+ *
+ */
+@Mojo(name = "create-git-diff")
+public class ScmDiffMojo extends AbstractMojo {
+
+    //This command contains both the branch name and the options because currently it is not possible
+    //to add options such as name-only to the scm:diff command.
+    //FIXME When this PR is merged https://github.com/apache/maven-scm/pull/75 the name-only option will be available.
+    //The double quotations are needed to escape the whitespace between master and --name-only
+    private static final String SCM_OPTION_BRANCH_AND_NAME_ONLY = "\"\"master --name-only \"\"";
+    private static final String SCM_OPTION_ONLY_SHOW_CHANGED_FILES_IN_CURRENT_FOLDER = "./";
+
+    private static final String MAVEN_SCM_PLUGIN_ARTIFACT_ID = "maven-scm-plugin";
+    private static final String MAVEN_SCM_PLUGIN_GROUP_ID = "org.apache.maven.plugins";
+    private static final String MAVEN_SCM_DIFF_GOAL = "diff";
+
+    static final String DEFAULT_DIFF_OUTPUT_FILE = "target/scm-changed-artifact-ids.diff";
+
+    /**
+     * The name of the diff file in which changed files will be written.
+     */
+    @Parameter(property = "diffOutputFile", defaultValue = DEFAULT_DIFF_OUTPUT_FILE)
+    protected String diffOutputFile;
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    protected MavenProject mavenProject;
+
+    @Parameter(defaultValue = "${session}", readonly = true)
+    protected MavenSession mavenSession;
+
+    @Component
+    private BuildPluginManager pluginManager;
+
+    @Parameter(property = "maven.scm.version", defaultValue = "1.10.0")
+    private String scmMavenVersion;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Xpp3Dom config = configuration(element("startScmVersionType", "branch"),
+                element("startScmVersion", SCM_OPTION_BRANCH_AND_NAME_ONLY), element("endScmVersionType", "branch"),
+                element("endScmVersion", SCM_OPTION_ONLY_SHOW_CHANGED_FILES_IN_CURRENT_FOLDER), element("outputFile", diffOutputFile));
+
+        Plugin plugin = MojoExecutor.plugin(MAVEN_SCM_PLUGIN_GROUP_ID, MAVEN_SCM_PLUGIN_ARTIFACT_ID, scmMavenVersion,
+                new ArrayList<>());
+
+        MojoExecutor.executeMojo(plugin, MAVEN_SCM_DIFF_GOAL, config,
+                MojoExecutor.executionEnvironment(mavenProject, mavenSession, pluginManager));
+    }
+
+}

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -96,6 +96,10 @@ public class CheckstyleChecker extends AbstractChecker {
 
     @Override
     public void execute() throws MojoExecutionException {
+        if (!shouldAnalyseModule()) {
+            return;
+        }
+
         Log log = getLog();
         Properties userProps = loadPropertiesFromFile(CHECKSTYLE_PROPERTIES_FILE);
 

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -76,6 +76,10 @@ public class PmdChecker extends AbstractChecker {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!shouldAnalyseModule()) {
+            return;
+        }
+
         Log log = getLog();
 
         Properties userProps = loadPropertiesFromFile(PMD_PROPERTIES_FILE);

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -138,6 +138,10 @@ public class SpotBugsChecker extends AbstractChecker {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!shouldAnalyseModule()) {
+            return;
+        }
+
         Log log = getLog();
 
         Properties userProps = loadPropertiesFromFile(SPOTBUGS_PROPERTIES_FILE);


### PR DESCRIPTION
One of the steps suggested in #232 to improve build time.

Create two more static-analysis-tool goals and modify the existing ones to allow only bundles, in which there were changes to be checked thus saving a lot of time.

The first goal "create-scm-diff" is implemented in the ScmDiffMojo class. In this goal, "git diff master --names-only ./" is called to create a file, containing the names of all changed files in the module. This file is created for each module.

The second goal "find-changed-bundles" is implemented in the FindChangedBundlesMojo class. In this goal, for every changed file, the artifactId of the first parent pom is taken, and a maven property artifactIds is set that contains the comma-separated values of all the artifactIds.

These two goals should be executed in the package phase.

Later, when checkstyle, pmd and findbugs goals start executing in the verify phase, the code checks whether the current artifactId is contained in the artifactIds maven property and if it is contained, the goal is executed. If it is not contained, the bundle is not checked by checkstyle, pmd and findbugs.

In order for this to work, a separate profile in the smarthome pom needs to be added:

```<profile>
  <id>only-check-changed</id>
  <activation>
    <property>
      <name>onlyCheckChanged</name>
      <value>true</value>
    </property>
  </activation>
  <build>
    <pluginManagement>
      <plugins>
        <plugin>
          <groupId>org.openhab.tools.sat</groupId>
          <artifactId>sat-plugin</artifactId>
          <configuration>
            <diffOutputFile>target/smarthome.diff</diffOutputFile>
          </configuration>
          <executions>
            <execution>
              <id>create-diff-files</id>
              <goals>
                <goal>create-git-diff</goal>
                <goal>find-changed-bundles</goal>
              </goals>
              <phase>package</phase>
            </execution>
          </executions>
        </plugin>
      </plugins>
    </pluginManagement>
  </build>
</profile>
```
Additionally, In the project configuration, a scm configuration element must be added with the scm directory.

```
  <scm>
    <connection>scm:git:file:/.git</connection>
  </scm>
```

Also 
```<onlyCheckChanged>false</onlyCheckChanged>``` must be added as a property with default value false.

After adding these things to the smarthome pom configuration, the build should be executed with:
```mvn clean install -DonlyCheckChanged```. 



Signed-off-by:_ Lyubomir V. Papazov <lpapazow@gmail.com>