### PR TITLE
create a filter to suppress violations in git ignored files

### DIFF
--- a/custom-checks/checkstyle/pom.xml
+++ b/custom-checks/checkstyle/pom.xml
@@ -72,5 +72,10 @@
       <artifactId>org.eclipse.jdt.annotation</artifactId>
       <version>${jdt-annotations.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>${jgit.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/filters/GitIgnoredFilesFilter.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/filters/GitIgnoredFilesFilter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2010-2018 by the respective copyright holders.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.tools.analysis.checkstyle.filters;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.NoWorkTreeException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import com.puppycrawl.tools.checkstyle.api.AuditEvent;
+import com.puppycrawl.tools.checkstyle.filters.SuppressionFilter;
+
+/**
+ * @author Lyubomir Papazov - Initial contribution
+ * 
+ *         A filter that suppresses all checks for files that are ignored by
+ *         git. In order to activate the filter, A module with the full class
+ *         name should be added within the Checker module in the rules file.
+ */
+public class GitIgnoredFilesFilter extends SuppressionFilter {
+
+    private Set<Path> ignoredFiles = null;
+
+    private final Log logger = LogFactory.getLog(GitIgnoredFilesFilter.class);
+
+    public GitIgnoredFilesFilter() throws NoWorkTreeException, GitAPIException {
+        FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
+        Repository repository;
+        try {
+            repository = repositoryBuilder.findGitDir().setMustExist(true).build();
+            Path pathToRepo = repository.getWorkTree().toPath();
+            Git git = new Git(repository);
+            Set<String> ignoredFileNames = git.status().call().getIgnoredNotInIndex();
+            ignoredFiles = ignoredFileNames.stream().map(pathToRepo::resolve).collect(Collectors.toSet());
+        } catch (IOException e) {
+            logger.error("An error occurred trying to get all .git ignored files.", e);
+        }
+    }
+
+    /*
+     * Determines whether or not a filtered AuditEvent is accepted.
+     *  If the file is ignored by git, the AuditEvent is not accepted.
+     */
+    @Override
+    public boolean accept(AuditEvent event) {
+        if (ignoredFiles == null || ignoredFiles.isEmpty()) {
+            return true;
+        }
+        String fileName = event.getFileName();
+        return !ignoredFiles.contains(Paths.get(fileName));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <maven.surefire.plugin.version>2.12.4</maven.surefire.plugin.version>
     <jetty.server.version>9.3.14.v20161028</jetty.server.version>
     <saxon.version>9.1.0.8</saxon.version>
+    <jgit.version>5.1.1.201809181055-r</jgit.version>
   </properties>
 
   <distributionManagement>

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -12,6 +12,7 @@
  -->
 
 <module name="Checker">
+  <module name="org.openhab.tools.analysis.checkstyle.filters.GitIgnoredFilesFilter"/>
 
   <!-- Allow to skip parsing of files, see https://github.com/checkstyle/checkstyle/issues/5629#issuecomment-375126473 -->
   <!-- Add default to skip unhandled Java 9 sources -->


### PR DESCRIPTION
Provides a solution for #255.

With the addition of this filter, checkstyle violations for git ignored files will not be logged.

The current solution for #255 is to add supressions for each check in smarthome checkstyle/suppressions.xml file. However, the suppressions file needs to be updated every time in every repo when a new check is added or renamed. Having this filter should allow this to be avoided.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>