### PR TITLE
minor changes to NullAnnotationChek tests to be compliant with checkstyle 8.9 API

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
@@ -8,8 +8,6 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.openhab.tools.analysis.checkstyle.NullAnnotationsCheck;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
@@ -28,11 +26,15 @@ public class NullAnnotationsCheckTest extends AbstractStaticCheckTest {
     private static final String EXPECTED_WARNING_MESSAGE_MISSING_CLASS_ANNOTATION = "Classes/Interfaces should be annotated with @NonNullByDefault";
     private static final String EXPECTED_WARNING_MESSAGE_NONNULL_ANNOTATION = "There is no need for a @NonNull annotation because it is set as default. Only @Nullable should be used";
 
-    private static final String TEST_DIRECTORY_NAME = "nullAnnotationsCheckTest";
-
     private static final String ATTRIBUTE_NAME = "checkInnerUnits";
 
-    private DefaultConfiguration configuration = createCheckConfig(NullAnnotationsCheck.class);
+    private DefaultConfiguration configuration = createModuleConfig(NullAnnotationsCheck.class);
+
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/nullAnnotationsCheckTest";
+    }
 
     @Test
     public void testClassWithNoAnnotation() throws Exception {
@@ -133,7 +135,7 @@ public class NullAnnotationsCheckTest extends AbstractStaticCheckTest {
     }
 
     private void checkFile(String fileName, boolean checkInnerUnits, String... expectedMessages) throws Exception {
-        String filePath = getPath(TEST_DIRECTORY_NAME + File.separator + fileName);
+        String filePath = getPath(fileName);
         configuration.addAttribute(ATTRIBUTE_NAME, String.valueOf(checkInnerUnits));
         verify(configuration, filePath, expectedMessages);
     }


### PR DESCRIPTION
Merging #281 caused compilation errors.

When #281 was first introduced checkstyle 8.1 was used but checkstyle 8.9 has a slightly different test API.
Made some minor changes so that NullAnnotationsCheckTest.java compiles.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>