### PR TITLE
Update EshInfXmlValidationCheckTest to match new version of thing-des…

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlValidationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/EshInfXmlValidationCheckTest.java
@@ -126,7 +126,7 @@ public class EshInfXmlValidationCheckTest extends AbstractStaticCheckTest {
 
         int lineNumber = 18;
         String[] expectedMessages = generateExpectedMessages(lineNumber,
-                "Invalid content was found starting with element item-type. One of {category, tags, state, event, config-description, config-description-ref} is expected.");
+                "Invalid content was found starting with element item-type. One of {category, tags, state, event, autoUpdatePolicy, config-description, config-description-ref} is expected.");
         verifyWithPath("sequenceChannelTypeCheck", RELATIVE_PATH_TO_THING, expectedMessages);
     }
 


### PR DESCRIPTION
Update one of the test cases in EshInfXmlValidationCheckTest to match [this change](https://github.com/eclipse/smarthome/commit/1aade3a9d901bd6760ede51114730e16a832c5eb#diff-55402b0b0c8a54aa118ac6cc3ffe0e34R74) in the thing-description.xsd schema.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>