### PR TITLE
add defualt values for forbiddenPackages and forbiddenPackageUsageCh…

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -201,8 +201,8 @@
     </module>
     <module name="org.openhab.tools.analysis.checkstyle.ForbiddenPackageUsageCheck">
       <property name="severity" value="warning" />
-      <property name="forbiddenPackages" value="${checkstyle.forbiddenPackageUsageCheck.forbiddenPackages}"/>
-      <property name="exceptions" value="${checkstyle.forbiddenPackageUsageCheck.exceptions}"/>
+      <property name="forbiddenPackages" value="${checkstyle.forbiddenPackageUsageCheck.forbiddenPackages}" default=""/>
+      <property name="exceptions" value="${checkstyle.forbiddenPackageUsageCheck.exceptions}" default=""/>
     </module>
     <module name="UnusedImports">
       <property name="processJavadoc" value="true"/>


### PR DESCRIPTION
Add default values for `checkstyle.forbiddenPackageUsageCheck.forbiddenPackages` and
checkstyle.forbiddenPackageUsageCheck.exceptions.

This is necessary because eSH and other repos that have their own 'checkstyle.properties' currently don't have these properties defined and the build fails.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>