### PR TITLE
add javax dependencies that are not in JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,28 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <checkstyleFilter>tools/suppressions.xml</checkstyleFilter>
           <checkstyleProperties>tools/checkstyle.properties</checkstyleProperties>
@@ -186,6 +208,26 @@
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Fixes #325 

The included libraries are not part of JDK 9. Spotbugs checks depend on these libraries. After adding them as dependencies, eSH builds successfully with both java8 and java9.

I added these dependencies twice - once in the `<project>` dependencies in order for the plugin to work when it's called in eSH.

I also added them as `<plugin>` dependenceis for the `sat-plugin:0.4.1` which is the version of the plugin used to perform code analysis for the tool itself. These dependencies are only necessary when building with java9 and will no longer be required once we start using `sat-plugin:0.6.0` to do the code analysis for the tool.


Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>