### PR TITLE
Update suppression.xml for use of OnlyTabIndentationCheck

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/suppressions.xml
@@ -23,6 +23,6 @@
     <suppress files=".+org.openhab.voice.voicerss.+" checks="PackageExportsNameCheck"/>
     <!--  Allow the usage of scheduleAtFixedRate in FadingWiFiLEDDriver class  -->
     <suppress files=".+org.openhab.binding.wifiled.handler.FadingWiFiLEDDriver.java" checks="AvoidScheduleAtFixedRateCheck"/>
-    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationInXmlFilesCheck"/>
-    <suppress files=".+[\\/]OSGI-INF[\\/]org.openhab.+\.xml" checks="OnlyTabIndentationInXmlFilesCheck|NewlineAtEndOfFileCheck"/>
+    <suppress files=".+[\\/]pom\.xml" checks="OnlyTabIndentationCheck"/>
+    <suppress files=".+[\\/]OSGI-INF[\\/]org.openhab.+\.xml" checks="OnlyTabIndentationCheck|NewlineAtEndOfFileCheck"/>
 </suppressions>


### PR DESCRIPTION
In #313 the `OnlyTabIndentationInXmlFilesCheck` was renamed to `OnlyTabIndentationCheck` but the `suppressions.xml` file was not updated accordingly.