### PR TITLE
Upgrade maven-pmd-plugin to fix incremental analysis warnings

### DIFF
--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -86,7 +86,7 @@ Parameters:
 | ------ | ------| -------- |
 | **pmdRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **pmdFilter** | String | Relative path of a suppression.properties file that lists classes and rules to be excluded from failures. If not set no classes and no rules will be excluded |
-| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.7**)|
+| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.11.0**)|
 | **pmdPlugins** | List<Dependency> | A list with artifacts that contain additional checks for PMD |
 
 ### sat-plugin:checkstyle

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -57,7 +57,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.9.0")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.11.0")
     private String mavenPmdVersion;
 
     /**


### PR DESCRIPTION
Upgrades the maven-pmd-plugin to 3.11.0 which has a fix for [MPMD-257](https://issues.apache.org/jira/browse/MPMD-257).

Fixes #330