### PR TITLE
Fix broken PomXmlCheck

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
@@ -73,7 +73,7 @@ public class PomXmlCheck extends AbstractStaticCheck {
     private String pomPath;
     private boolean checkPomVersion;
 
-    public void setCheckPomVersions(boolean value) {
+    public void setCheckPomVersion(boolean value) {
         checkPomVersion = value;
     }
 

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -46,7 +46,7 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
     @BeforeClass
     public static void setUpClass() {
         config = createModuleConfig(PomXmlCheck.class);
-        config.addAttribute("checkPomVersions", "true");
+        config.addAttribute("checkPomVersion", "true");
     }
 
     @Override

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -143,7 +143,7 @@
   
   <module name="org.openhab.tools.analysis.checkstyle.PomXmlCheck">
     <property name="severity" value="error" />
-    <property name="checkPomVersion" value="${checkstyle.PomXmlCheck.checkPomVersion}" default="true"/>
+    <property name="checkPomVersion" value="${checkstyle.pomXmlCheck.checkPomVersion}" default="true"/>
   </module>
   
   <module name="org.openhab.tools.analysis.checkstyle.PackageExportsNameCheck">


### PR DESCRIPTION
After testing SAT 0.6.0 it seems the release is unusable because with https://github.com/openhab/static-code-analysis/pull/306 it always fails the build with the following error:

`Unable to execute mojo: An error has occurred in Checkstyle report generation. Failed during checkstyle configuration: cannot initialize module org.openhab.tools.analysis.checkstyle.PomXmlCheck - Property 'checkPomVersion' in module org.openhab.tools.analysis.checkstyle.PomXmlCheck does not exist, please check the documentation`