### PR TITLE
Update root POM so SAT can be build using Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <junit.version>4.11</junit.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>2.6</commons.lang.version>
-    <mockito.version>2.8.47</mockito.version>
+    <mockito.version>2.25.0</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
     <pmd.version>6.7.0</pmd.version>
     <checkstyle.version>8.12</checkstyle.version>
@@ -207,8 +207,9 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.3</version>
+          <version>3.1.0</version>
           <configuration>
+              <source>8</source>
               <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
               <failOnError>true</failOnError>
           </configuration>


### PR DESCRIPTION
It can be easily validated when #345 is merged. If the build is green we can also change the Travis config so the Java 11 build is no longer allowed to fail. :-)