### PR TITLE
Update Travis configuration to require successful Java 11 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ before_install:
   - echo "MAVEN_OPTS='-Xms1g -Xmx2g'" > ~/.mavenrc
 install:
   - |
-    function extra_maven_opts() {
-        if [ "$TRAVIS_JDK_VERSION" != "openjdk8" ]; then echo "-Denforcer.skip=true"; fi;
-    }
     function prevent_timeout() {
         local i=0
         while [ -e /proc/$1 ]; do
@@ -46,9 +43,5 @@ after_success:
   - print_reactor_summary .build.log
 after_failure:
   - tail -n 2000 .build.log
-env: # required for allowing failures
-matrix:
-  allow_failures:
-    - jdk: openjdk11
 script:
-  - mvnp clean verify -B $(extra_maven_opts)
+  - mvnp clean verify -B


### PR DESCRIPTION
Now that the Java 11 build succeeds we should make sure it stays that way by not allowing any failures. 