### PR TITLE
Fix error on missing target in root.

### DIFF
--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtility.java
@@ -216,6 +216,7 @@ public class ReportUtility extends AbstractMojo {
 
             // 7. Append the individual report to the summary, if it is not empty
             if (summaryReportDirectory != null) {
+                ensureSummaryReportDirectoryExists();
                 generateSummaryByBundle(htmlOutputFileName, mergedReport);
                 generateSummaryByRules(htmlOutputFileName, mergedReport);
             }
@@ -363,6 +364,12 @@ public class ReportUtility extends AbstractMojo {
             case "3":
             default:
                 getLog().debug(log);
+        }
+    }
+
+    private void ensureSummaryReportDirectoryExists() {
+        if (!summaryReportDirectory.exists()) {
+            summaryReportDirectory.mkdirs();
         }
     }
 


### PR DESCRIPTION
When running the build from root with `-pl` option the sat will give an `IOException` error if the target folder in the root from which the build is started. This target folder is used for summary report. This change makes sure the target directory exists.

Fixes:
```
[ERROR] Unable to create or write to file No such file or directory
java.io.IOException: No such file or directory
    at java.io.UnixFileSystem.createFileExclusively (Native Method)
    at java.io.File.createNewFile (File.java:1012)
    at org.openhab.tools.analysis.report.ReportUtility.generateSummaryByRules (ReportUtility.java:419)
    at org.openhab.tools.analysis.report.ReportUtility.execute (ReportUtility.java:220)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:134)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:208)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:154)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:146)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:51)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:309)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:194)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:107)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:955)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:290)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:194)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
```