### PR TITLE
Include src/test/java to Checkstyle/PMD

### DIFF
--- a/sat-plugin/src/main/resources/configuration/checkstyle.properties
+++ b/sat-plugin/src/main/resources/configuration/checkstyle.properties
@@ -1,6 +1,6 @@
 checkstyle.output.file=${project.build.directory}/code-analysis/checkstyle-result.xml
 checkstyle.console=true
-checkstyle.includes=src/main/java/**,src/main/resources/ESH-INF/**,.classpath,build.properties,pom.xml,README.md
+checkstyle.includes=src/main/java/**,src/main/resources/ESH-INF/**,src/test/java/**,.classpath,build.properties,pom.xml,README.md
 checkstyle.includeResources=false
 checkstyle.includeTestResources=false
 linkXRef=false

--- a/sat-plugin/src/main/resources/configuration/pmd.properties
+++ b/sat-plugin/src/main/resources/configuration/pmd.properties
@@ -1,4 +1,4 @@
 pmd.custom.targetDirectory=${project.build.directory}/code-analysis
-pmd.custom.compileSourceRoots=${project.build.directory}/../src/main/java
+pmd.custom.compileSourceRoots=${project.build.directory}/../src/main/java,${project.build.directory}/../src/test/java
 linkXRef=false
 outputEncoding=UTF-8


### PR DESCRIPTION
Many tests have been moved to src/test/java since the bnd migration which requires additional Checkstyle/PMD includes.

Fixes #359