### PR TITLE
Added specific formatting rules for feature.xml

### DIFF
--- a/codestyle/src/main/resources/openhab_wst_feature_file.prefs
+++ b/codestyle/src/main/resources/openhab_wst_feature_file.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+indentationChar=tab
+indentationSize=1
+lineWidth=10000
+outputCodeset=UTF-8


### PR DESCRIPTION
feature.xml files should have be line wrapped so set the lineWidth to a very high value (leaving it out will still format the line)