### PR TITLE
Update xsi:schemaLocation in POMs

### DIFF
--- a/custom-checks/checkstyle/pom.xml
+++ b/custom-checks/checkstyle/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/includedBundle/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/includedBundle/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/includedBundleWithParentGroupIdOnly/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/includedBundleWithParentGroupIdOnly/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/invalidBundle/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/invalidBundle/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/missingBundle/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/missingBundle/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/mulitpleFeatureFiles/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafFeatureCheck/mulitpleFeatureFiles/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/overridingParentPomConfigurationCheckTest/invalidPomConfiguration/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/overridingParentPomConfigurationCheckTest/invalidPomConfiguration/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<build>
 		<plugins>
 			<plugin>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/overridingParentPomConfigurationCheckTest/missingOverridingParentPomConfiguration/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/overridingParentPomConfigurationCheckTest/missingOverridingParentPomConfiguration/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<build>
 		<plugins>
 			<plugin>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/different_version_manifest_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/different_version_manifest_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/different_version_pom_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/different_version_pom_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_artifactId_in_pom_xml_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_artifactId_in_pom_xml_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_parent_pom_id_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_parent_pom_id_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_version_in_pom_xml_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/invalid_version_in_pom_xml_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_artifactId_in_pom_xml_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_artifactId_in_pom_xml_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_parent_pom_id_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_parent_pom_id_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_version_in_pom_xml_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/missing_version_in_pom_xml_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/pom_xml_with_different_version_than_parent/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/pom_xml_with_different_version_than_parent/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/valid_pom_xml_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/pomXmlCheckTest/valid_pom_xml_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.openhab.binding</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_build_properties_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_build_properties_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_manifest_mf_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_manifest_mf_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_notice_html_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_notice_html_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_readme_md_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/missing_readme_md_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/valid_directory/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/requiredFilesCheckTest/valid_directory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <parent>
     <groupId>org.eclipse.smarthome.bundles</groupId>

--- a/custom-checks/findbugs/pom.xml
+++ b/custom-checks/findbugs/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/pmd/pom.xml
+++ b/custom-checks/pmd/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidOverridingParentPomConfiguration.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/AvoidOverridingParentPomConfiguration.xml
@@ -8,7 +8,7 @@
     <code><![CDATA[
     
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <build>
     <plugins>
        <plugin>

--- a/custom-checks/pmd/src/test/resources/pmd/ruleset/pom.xml
+++ b/custom-checks/pmd/src/test/resources/pmd/ruleset/pom.xml
@@ -22,7 +22,7 @@
     <example>
 <![CDATA[
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   ...
   <environments combine.self="override"></environments>
   ...

--- a/custom-checks/pom.xml
+++ b/custom-checks/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/sat-plugin/pom.xml
+++ b/sat-plugin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Updates the xsi:schemaLocation in POMs
from: http://maven.apache.org/maven-v4_0_0.xsd
to: http://maven.apache.org/xsd/maven-4.0.0.xsd

See: https://github.com/openhab/static-code-analysis/pull/365#discussion_r360726697