### PR TITLE
Switch to Java 11 and upgrade JAXB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: required
-dist: xenial
+dist: bionic
 
 language: java
 
-jdk:
-  - openjdk8
-  - openjdk11
+jdk: openjdk11
 
 cache:
   directories:

--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,10 @@
     <pmd.version>6.7.0</pmd.version>
     <checkstyle.version>8.12</checkstyle.version>
     <spotbugs.version>3.1.12</spotbugs.version>
-    <maven.core.version>3.5.0</maven.core.version>
-    <maven.plugin.api.version>3.5.0</maven.plugin.api.version>
-    <maven.plugin.annotations.version>3.5</maven.plugin.annotations.version>
-    <maven.plugin.plugin.version>3.5</maven.plugin.plugin.version>
+    <maven.core.version>3.6.0</maven.core.version>
+    <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
+    <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>
+    <maven.plugin.plugin.version>3.6.0</maven.plugin.plugin.version>
     <maven.plugin.compiler.version>3.6.1</maven.plugin.compiler.version>
     <mojo.executor.version>2.3.0</mojo.executor.version>
     <org.apache.ivy.version>2.4.0</org.apache.ivy.version>
@@ -143,6 +143,11 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -165,8 +170,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.plugin.compiler.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
         <executions>
           <execution>
@@ -208,9 +212,9 @@
       <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.1.1</version>
           <configuration>
-              <source>8</source>
+              <source>11</source>
               <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
               <failOnError>true</failOnError>
           </configuration>
@@ -225,6 +229,25 @@
                   </configuration>
               </execution>
           </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[11.0,12.0)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
     <extensions>
@@ -246,22 +269,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.2.11</version>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-      <version>2.2.11</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>2.3.1</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <version>2.2.11</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.activation</groupId>
-      <artifactId>activation</artifactId>
-      <version>1.1.1</version>
+        <groupId>com.sun.activation</groupId>
+        <artifactId>javax.activation</artifactId>
+        <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/sat-extension/pom.xml
+++ b/sat-extension/pom.xml
@@ -44,7 +44,7 @@
       <plugin>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-metadata</artifactId>
-        <version>1.7.1</version>
+        <version>2.1.0</version>
         <executions>
           <execution>
             <goals>

--- a/sat-plugin/pom.xml
+++ b/sat-plugin/pom.xml
@@ -34,13 +34,19 @@
       <groupId>org.apache.maven.plugins</groupId>
       <artifactId>maven-plugin-plugin</artifactId>
       <version>${maven.plugin.plugin.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- MOJO Executor -->
     <dependency>
-        <groupId>org.twdata.maven</groupId>
-        <artifactId>mojo-executor</artifactId>
-        <version>${mojo.executor.version}</version>
+      <groupId>org.twdata.maven</groupId>
+      <artifactId>mojo-executor</artifactId>
+      <version>${mojo.executor.version}</version>
     </dependency>
     
     <!-- Saxon dependency -->


### PR DESCRIPTION
When #371 is merged SAT won't be compatible with OH 2.5.x anymore so that would also allow us to make it Java 11 only.

Upgrading JAXB fixes the "illegal reflective access operations" warnings reported in #366.

There's still one such warning remaining due to the spotbugs-maven-plugin usage of the Groovy ReflectionUtils class.

See: https://github.com/spotbugs/spotbugs-maven-plugin/issues/132