### PR TITLE
fix xml formatting

### DIFF
--- a/codestyle/src/main/resources/openhab_wst_feature_file.prefs
+++ b/codestyle/src/main/resources/openhab_wst_feature_file.prefs
@@ -3,3 +3,4 @@ indentationChar=tab
 indentationSize=1
 lineWidth=10000
 outputCodeset=UTF-8
+spaceBeforeEmptyCloseTag=false

--- a/codestyle/src/main/resources/openhab_wst_pom_file.prefs
+++ b/codestyle/src/main/resources/openhab_wst_pom_file.prefs
@@ -3,3 +3,4 @@ indentationChar=space
 indentationSize=2
 lineWidth=120
 outputCodeset=UTF-8
+spaceBeforeEmptyCloseTag=false

--- a/codestyle/src/main/resources/openhab_wst_xml_files.prefs
+++ b/codestyle/src/main/resources/openhab_wst_xml_files.prefs
@@ -3,3 +3,4 @@ indentationChar=tab
 indentationSize=1
 lineWidth=120
 outputCodeset=UTF-8
+spaceBeforeEmptyCloseTag=false


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/6874

remove space before empty closing tag

Signed-off-by: Jan N. Klug <jan.n.klug@rub.de>