### PR TITLE
Added Eclipse formatter rules to remove empty lines at end of code blocks

### DIFF
--- a/codestyle/src/main/resources/openhab_codestyle.xml
+++ b/codestyle/src/main/resources/openhab_codestyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="16">
-	<profile kind="CodeFormatterProfile" name="openHAB" version="16">
+<profiles version="18">
+	<profile kind="CodeFormatterProfile" name="openHAB" version="18">
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression"
@@ -33,13 +33,18 @@
 			value="common_lines" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_default" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.align_with_spaces" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off" />
 		<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2" />
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_before_code_block" value="0" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_switch_case_expressions"
+			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49" />
 		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1" />
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_method_body" value="-1" />
 		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations"
 			value="insert" />
@@ -58,6 +63,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter"
 			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.wrap_before_multiplicative_operator" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert" />
@@ -112,6 +118,7 @@
 			value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_abstract_method" value="1" />
 		<setting id="org.eclipse.jdt.core.formatter.keep_enum_constant_declaration_on_one_line" value="one_line_never" />
 		<setting id="org.eclipse.jdt.core.formatter.align_variable_declarations_on_columns" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation"
@@ -137,6 +144,8 @@
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiplicative_operator" value="16" />
 		<setting id="org.eclipse.jdt.core.formatter.keep_anonymous_type_declaration_on_one_line"
 			value="one_line_never" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_switch_case_expressions"
+			value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.wrap_before_shift_operator" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header"
 			value="true" />
@@ -146,6 +155,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line" />
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_end_of_code_block" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters"
 			value="do not insert" />
@@ -189,12 +199,14 @@
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert" />
+		<setting id="org.eclipse.jdt.core.formatter.text_block_indentation" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_module_statements" value="16" />
 		<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration"
 			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_after_code_block" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.comment.align_tags_names_descriptions" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant"
 			value="do not insert" />
@@ -213,7 +225,10 @@
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_default" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration"
+			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_between_different_tags"
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression_chain" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false" />
@@ -274,6 +289,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.wrap_before_assignment_operator" value="false" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement"
 			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_not_operator" value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces"
 			value="do not insert" />
@@ -325,6 +341,7 @@
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments"
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_arrow_in_switch_case" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement"
@@ -371,6 +388,7 @@
 		<setting
 			id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression"
 			value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="-1" />
 		<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments"
@@ -384,6 +402,7 @@
 			value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert" />
+		<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_statement_group_in_switch" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference"
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert" />
@@ -441,6 +460,7 @@
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert" />
 		<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="true" />
+		<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_code_block" value="0" />
 		<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement"
 			value="do not insert" />
 		<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space" />


### PR DESCRIPTION
Based on requested changes during review of https://github.com/openhab/openhab-addons/pull/5576 and https://github.com/openhab/openhab-addons/pull/5077 by @J-N-K

In order for the rules to actually apply **Eclipse 4.13 is needed** (current setup installs 4.11(?)). This applies to both the Spotless plugin (bump to latest 1.27.0) and the eclipse configuration block (must bump to 4.13.0 (all relevant git repos where spotless is employed).

In the codestyle file there are some other new rules that have been initialized to their default settings by Eclipse.