### PR TITLE
Update PMD to 6.22.0

### DIFF
--- a/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
+++ b/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
@@ -47,7 +47,8 @@ public class UseSLF4JLoggerRule extends AbstractJavaRule {
         String fullImportName = node.getImportedName();
         if (forbiddenLoggers.contains(fullImportName)) {
             addViolation(data, node);
-        } else if ("org.slf4j.Logger".equals(fullImportName) || ("org.slf4j".equals(fullImportName) && node.isImportOnDemand())) {
+        } else if ("org.slf4j.Logger".equals(fullImportName)
+                || ("org.slf4j".equals(fullImportName) && node.isImportOnDemand())) {
             isSlf4jPackageImported = true;
         }
         return super.visit(node, data);
@@ -55,10 +56,11 @@ public class UseSLF4JLoggerRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTVariableDeclarator node, Object data) {
-        ASTType typeNode = node.jjtGetParent().getFirstChildOfType(ASTType.class);
-        Node reftypeNode = typeNode.jjtGetChild(0);
+        ASTType typeNode = node.getParent().getFirstChildOfType(ASTType.class);
+        Node reftypeNode = typeNode.getChild(0);
         if (reftypeNode instanceof ASTReferenceType) {
-            ASTClassOrInterfaceType classOrInterfaceType = reftypeNode.getFirstChildOfType(ASTClassOrInterfaceType.class);
+            ASTClassOrInterfaceType classOrInterfaceType = reftypeNode
+                    .getFirstChildOfType(ASTClassOrInterfaceType.class);
             if (classOrInterfaceType != null) {
                 String className = classOrInterfaceType.getImage();
 
@@ -74,9 +76,8 @@ public class UseSLF4JLoggerRule extends AbstractJavaRule {
         if (forbiddenLoggers.contains(className)) {
             return true;
         }
-        //If the classname is Logger but org.slf4j is not in the imports,
+        // If the classname is Logger but org.slf4j is not in the imports,
         // that means the current Logger literal is not a sfl4j.Logger
         return LOGGER_LITERAL.equals(className) && !isSlf4jPackageImported;
     }
 }
-

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -86,7 +86,7 @@ Parameters:
 | ------ | ------| -------- |
 | **pmdRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **pmdFilter** | String | Relative path of a suppression.properties file that lists classes and rules to be excluded from failures. If not set no classes and no rules will be excluded |
-| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.11.0**)|
+| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.13.0**)|
 | **pmdPlugins** | List<Dependency> | A list with artifacts that contain additional checks for PMD |
 
 ### sat-plugin:checkstyle

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <commons.lang.version>2.6</commons.lang.version>
     <mockito.version>2.25.0</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
-    <pmd.version>6.7.0</pmd.version>
+    <pmd.version>6.22.0</pmd.version>
     <checkstyle.version>8.30</checkstyle.version>
     <spotbugs.version>4.0.1</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -60,7 +60,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.11.0")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.13.0")
     private String mavenPmdVersion;
 
     /**
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "6.7.0";
+    private static final String PMD_VERSION = "6.22.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */

--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -74,7 +74,7 @@
   <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton">
     <priority>3</priority>
   </rule>
-  <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter">
+  <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter">
     <priority>3</priority>
   </rule>
   


### PR DESCRIPTION
Updates PMD from 6.7.0 to 6.22.0

For release notes see:

* https://pmd.github.io/latest/pmd_release_notes.html
* https://pmd.github.io/latest/pmd_release_notes_old.html

After going through all those many changes, updating to the newer version results in:

* Support for newer Java versions
* Fixes for false positives/negatives
* More rules we could use such as [UseDiamondOperator](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#usediamondoperator)
* Deprecations of several PMD classes in preparation for PMD 7.0.0 where they will be removed (builders have been introduced and APIs have become less specific to Java)

I've fixed the deprecations impacting SAT:
* `UseSLF4JLoggerRule` now uses the generic API methods instead of the deprecated Java specific methods
* The [UnsynchronizedStaticDateFormatter](https://pmd.github.io/latest/pmd_rules_java_multithreading.html#unsynchronizedstaticdateformatter) rule has been deprecated in favor of the [UnsynchronizedStaticFormatter](https://pmd.github.io/latest/pmd_rules_java_multithreading.html#unsynchronizedstaticformatter) which would cause the following warnings during execution:

`[WARNING] Discontinue using Rule name category/java/multithreading.xml/UnsynchronizedStaticDateFormatter as it is scheduled for removal from PMD. PMD 7.0.0 will remove support for this Rule.`