### PR TITLE
Fix UseSLF4JLoggerRule throws NPEs with Java 10+ var type

### DIFF
--- a/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
+++ b/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
@@ -57,15 +57,17 @@ public class UseSLF4JLoggerRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTVariableDeclarator node, Object data) {
         ASTType typeNode = node.getParent().getFirstChildOfType(ASTType.class);
-        Node reftypeNode = typeNode.getChild(0);
-        if (reftypeNode instanceof ASTReferenceType) {
-            ASTClassOrInterfaceType classOrInterfaceType = reftypeNode
-                    .getFirstChildOfType(ASTClassOrInterfaceType.class);
-            if (classOrInterfaceType != null) {
-                String className = classOrInterfaceType.getImage();
+        if (typeNode != null) {
+            Node reftypeNode = typeNode.getChild(0);
+            if (reftypeNode instanceof ASTReferenceType) {
+                ASTClassOrInterfaceType classOrInterfaceType = reftypeNode
+                        .getFirstChildOfType(ASTClassOrInterfaceType.class);
+                if (classOrInterfaceType != null) {
+                    String className = classOrInterfaceType.getImage();
 
-                if (isClassNameForbidden(className)) {
-                    addViolation(data, typeNode);
+                    if (isClassNameForbidden(className)) {
+                        addViolation(data, typeNode);
+                    }
                 }
             }
         }

--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/UseSLF4JLoggerRule.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/UseSLF4JLoggerRule.xml
@@ -64,9 +64,9 @@ class Foo{
 ]]></code>
   </test-code>
   <test-code reinitializeRule="true" regressionTest="true">
-  <description>Real smarthome class</description>
-  <expected-problems>0</expected-problems>
-  <code><![CDATA[
+    <description>Real smarthome class</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
 /**
  * Copyright (c) 2014,2018 Contributors to the Eclipse Foundation
  *
@@ -189,7 +189,20 @@ public class RawType implements PrimitiveType, State {
     }
 
 }
-
-  ]]></code>
+]]></code>
+  </test-code>
+  <test-code reinitializeRule="true" regressionTest="true">
+    <description>Unresolved inferred var types</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+class Foo {
+    Foo() {
+        var oh = "openHAB";
+        var obj1 = new Object();
+        var obj2 = null;
+        var i = 1;
+    }
+}
+]]></code>
   </test-code>
 </test-data>


### PR DESCRIPTION
The PMD type resolution for inferred types using the `var` keyword is very simple (see [Java 10 Support](https://pmd.github.io/latest/pmd_release_notes_old.html#java-10-support)).
As a result it's usually not possible to get the type of such variables during analysis.
So for now it's probably best to make sure not any NPEs occur whenever the type cannot be inferred.
Since `var` can only be used with local variables, it's not likely loggers will be instantiated often this way.

Fixes #379

---

Draft because this builds upon the changes made in `UseSLF4JLoggerRule` part of https://github.com/openhab/static-code-analysis/pull/380