### PR TITLE
Don't check inner classes for missing @NonNullByDefault

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -230,7 +230,7 @@
     
     <module name="org.openhab.tools.analysis.checkstyle.NullAnnotationsCheck">
       <property name="severity" value="warning"/>
-      <property name="checkInnerUnits" value="true"/>
+      <property name="checkInnerUnits" value="false"/>
     </module>
 
     <!-- Rules for Java Naming Convention -->


### PR DESCRIPTION
As a result there will still be a warning for annotating the outer class when @NonNullByDefault is missing.
It is redundant to annotate inner classes when outer classes are annotated.
The compiler generates warnings when both outer and inner classes are annotated.

Fixes #351

---

Example:

![example](https://user-images.githubusercontent.com/12213581/78450772-47761080-7681-11ea-90d6-b91193cadbf9.png)
