### PR TITLE
Fix NoEmptyLineSeparatorCheck false positives

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
@@ -205,6 +205,10 @@ public class NoEmptyLineSeparatorCheck extends AbstractCheck {
         switch (ast.getType()) {
             case TokenTypes.LITERAL_CASE:
             case TokenTypes.LITERAL_DEFAULT: {
+                if (ast.getParent().getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
+                    // annotation field defaults don't have a curly
+                    return null;
+                }
                 DetailAST nextNode = ast.getParent().getNextSibling();
                 return (nextNode != null) ? ast : null;
             }
@@ -223,6 +227,10 @@ public class NoEmptyLineSeparatorCheck extends AbstractCheck {
         switch (ast.getType()) {
             case TokenTypes.LITERAL_DEFAULT:
             case TokenTypes.LITERAL_CASE: {
+                if (ast.getParent().getType() == TokenTypes.ANNOTATION_FIELD_DEF) {
+                    // annotation field defaults don't have a curly
+                    return null;
+                }
                 /*
                  * cases are nested in case groups(a group of case clauses),
                  * we are searching for the case in the next case group or

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
@@ -228,11 +228,16 @@ public class NoEmptyLineSeparatorCheckTest extends AbstractStaticCheckTest {
     }
 
     @Test
-    public void verifyMutlitpleEmptyLinesInSwitchWithCases() throws Exception {
+    public void verifyMultipleEmptyLinesInSwitchWithCases() throws Exception {
         String[] expectedMessages = generateExpectedMessages(12, MSG_LINE_AFTER_OPENING_BRACE_EMPTY, 29,
                 MSG_LINE_BEFORE_CLOSING_BRACE_EMPTY, 16, MSG_LINE_BEFORE_CLOSING_BRACE_EMPTY, 19, MSG_FOR_EMPTY_LINE,
                 27, MSG_LINE_BEFORE_CLOSING_BRACE_EMPTY);
         verifyJavaFile("MutlitpleEmptyLinesInSwitchWithCases.java", expectedMessages);
+    }
+
+    @Test
+    public void verifyValidAnnotationInterface() throws Exception {
+        verifyJavaFileNoErrors("ValidAnnotationInterface.java");
     }
 
     @Test

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/noEmptyLineSeparatorCheck/ValidAnnotationInterface.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/noEmptyLineSeparatorCheck/ValidAnnotationInterface.java
@@ -1,0 +1,18 @@
+import static java.lang.annotation.ElementType.FIELD;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface TestInterface {
+    
+    String property1() default "";
+
+    String property2() default "";
+
+    String property2() default "";
+
+}


### PR DESCRIPTION
The check would generate false positives on annotation interfaces because these also have "default" tokens.

Examples are:

* org.openhab.core.automation.annotation.ActionInput
* org.openhab.binding.mqtt.generic.mapping.MQTTvalueTransform