### PR TITLE
[custom] Fix for feature check to ignore bindings with no feature file

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
@@ -46,6 +46,15 @@ public class KarafAddonFeatureCheckTest extends AbstractStaticCheckTest {
     }
 
     @Test
+    public void testExcludeAddonPatterns() throws Exception {
+        DefaultConfiguration config = createModuleConfig(KarafAddonFeatureCheck.class);
+        config.addAttribute("excludeAddonPatterns", "excludeAddon.*");
+
+        verify(config, getPath("excludeAddonPatterns" + File.separator + POM_XML_FILE_NAME),
+                ArrayUtils.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
     public void testMissingFeatureFile() throws Exception {
         final File featureFile = new File(getPath("missingFeature"), FEATURE_XML_PATH);
 
@@ -75,16 +84,7 @@ public class KarafAddonFeatureCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testPatternFeatureName() throws Exception {
         DefaultConfiguration config = createModuleConfig(KarafAddonFeatureCheck.class);
-        config.addAttribute("featureNamePatterns", "openhab-binding-example:org.openhab.binding.someother");
-        verify(config, getPath("invalidFeatureName" + File.separator + FEATURE_XML_PATH),
-                ArrayUtils.EMPTY_STRING_ARRAY);
-    }
-
-    @Test
-    public void testExcludedFeatureName() throws Exception {
-        DefaultConfiguration config = createModuleConfig(KarafAddonFeatureCheck.class);
-        config.addAttribute("featureNamePatterns", "openhab-binding-example:org.openhab.binding.someother");
-        config.addAttribute("excludeFeatureNames", "org.openhab.binding.someother");
+        config.addAttribute("featureNameMappings", "openhab-binding-example:org.openhab.binding.someother");
         verify(config, getPath("invalidFeatureName" + File.separator + FEATURE_XML_PATH),
                 ArrayUtils.EMPTY_STRING_ARRAY);
     }

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/karafAddonFeatureCheck/excludeAddonPatterns/pom.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/karafAddonFeatureCheck/excludeAddonPatterns/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>org.openhab.addons.bundles</groupId>
+    <artifactId>org.openhab.addons.reactor.bundles</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>org.openhab.binding.example</artifactId>
+
+  <name>openHAB Add-ons :: Bundles :: Example Binding</name>
+
+</project>

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -161,9 +161,9 @@
 
 	<module name="org.openhab.tools.analysis.checkstyle.KarafAddonFeatureCheck">
 		<property name="severity" value="${checkstyle.karafAddonFeatureCheck.severity}" default="error"/>
-		<property name="featureNamePatterns" value="${checkstyle.karafAddonFeatureCheck.featureNamePatterns}"
+		<property name="featureNameMappings" value="${checkstyle.karafAddonFeatureCheck.featureNameMappings}"
 			default=""/>
-		<property name="excludeFeatureNames" value="${checkstyle.karafAddonFeatureCheck.excludeFeatureNames}"
+		<property name="excludeAddonPatterns" value="${checkstyle.karafAddonFeatureCheck.excludeAddonPatterns}"
 			default=""/>
 	</module>
 


### PR DESCRIPTION
After running this check on the current openhab-addons repo I found out the modbus has no feature file anymore. The check could not handle such cases and not be configured to ignore it. So I've changed the configuration settings, and also renamed it to better reflect what it actually does.
