### PR TITLE
Added checks for starred imports and braces around code blocks

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -186,6 +186,10 @@
 		<module name="OneStatementPerLine">
 			<property name="severity" value="info"/>
 		</module>
+		<!-- See https://checkstyle.sourceforge.io/config_blocks.html#NeedBraces -->
+		<module name="NeedBraces">
+			<property name="severity" value="info"/>
+		</module>
 		<!-- See http://checkstyle.sourceforge.net/config_misc.html#TodoComment -->
 		<module name="TodoComment">
 			<property name="format" value="(TODO)|(FIXME)"/>
@@ -216,6 +220,11 @@
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true"/>
 			<property name="severity" value="info"/>
+		</module>
+		<!-- See https://checkstyle.sourceforge.io/config_imports.html#AvoidStarImport -->
+		<module name="AvoidStarImport">
+			<property name="allowStaticMemberImports" value="true"/>
+			<property name="severity" value="warn"/>
 		</module>
 
 		<module name="org.openhab.tools.analysis.checkstyle.AuthorTagCheck">


### PR DESCRIPTION
- Added checks for starred imports and braces around code blocks

Unfortunately spotless resolving wildcard imports is an unimplemented feature of spotless: diffplug/spotless#649

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>