### PR TITLE
Fix severity level

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -224,7 +224,7 @@
 		<!-- See https://checkstyle.sourceforge.io/config_imports.html#AvoidStarImport -->
 		<module name="AvoidStarImport">
 			<property name="allowStaticMemberImports" value="true"/>
-			<property name="severity" value="warn"/>
+			<property name="severity" value="warning"/>
 		</module>
 
 		<module name="org.openhab.tools.analysis.checkstyle.AuthorTagCheck">


### PR DESCRIPTION
- Fix severity level

Unfortunately I used a wrong severity level in my PR https://github.com/openhab/static-code-analysis/pull/408. This leads to a broken 0.11.0 release.

```
[ERROR] Failed to execute goal org.openhab.tools.sat:sat-plugin:0.11.0:checkstyle (sat-all) on project org.openhab.core.model.lazygen: Unable to execute mojo: Execution null of goal org.apache.maven.plugins:maven-checkstyle-plugin:3.1.1:checkstyle failed: No enum constant com.puppycrawl.tools.checkstyle.api.SeverityLevel.WARN -> [Help 1]
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>