### PR TITLE
Fixed CompareObjectsWithEquals is referenced multiple times warning

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -67,9 +67,6 @@
 	<rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause">
 		<priority>2</priority>
 	</rule>
-	<rule ref="category/java/errorprone.xml/CompareObjectsWithEquals">
-		<priority>3</priority>
-	</rule>
 	<rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty">
 		<priority>2</priority>
 	</rule>


### PR DESCRIPTION
- Fixed "CompareObjectsWithEquals is referenced multiple times" warning. It is listed a second time in "rules.xml" (line 52).
- 
```
[WARNING] The rule CompareObjectsWithEquals is referenced multiple times in "Default Ruleset". Only the last rule configuration is used.
```

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>