### PR TITLE
Tune logging

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
@@ -137,7 +137,7 @@ public class KarafAddonFeatureCheck extends AbstractStaticCheck {
         final String artifactId = getArtifactId(fileText);
 
         if (artifactId == null) {
-            logger.warn("{} will be skipped. Could not find Maven group ID (parent group ID) or artifact ID in {}",
+            logger.debug("{} will be skipped. Could not find Maven group ID (parent group ID) or artifact ID in {}",
                     getClass().getSimpleName(), file.getAbsolutePath());
             return;
         }

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -144,6 +144,6 @@ public abstract class AbstractChecker extends AbstractMojo {
      * @return Consumer
      */
     protected Consumer<? super Dependency> logDependency() {
-        return d -> getLog().info("Adding dependency to " + d.getArtifactId() + ":" + d.getVersion());
+        return d -> getLog().debug("Adding dependency to " + d.getArtifactId() + ":" + d.getVersion());
     }
 }


### PR DESCRIPTION
Changes these KarafAddonFeatureCheck warnings to debug:

```
[WARNING] KarafAddonFeatureCheck will be skipped. Could not find Maven group ID (parent group ID) or artifact ID in /home/jenkins/jenkins-agent1/workspace/PR-openHAB-Core/bundles/org.openhab.core.io.rest.voice/pom.xml
```

Logs dependency info on debug:

```
[INFO] Adding dependency to pmd:0.11.1
[INFO] Adding dependency to pmd-core:6.22.0
[INFO] Adding dependency to pmd-java:6.22.0
[INFO] Adding dependency to pmd-javascript:6.22.0
[INFO] Adding dependency to pmd-jsp:6.22.0
```