### PR TITLE
Upgrade flexmark to 0.60.0

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
@@ -47,9 +47,9 @@ import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
 import com.puppycrawl.tools.checkstyle.api.MessageDispatcher;
-import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.options.MutableDataSet;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.MutableDataSet;
 
 /**
  * Provides common functionality for different static code analysis checks

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
@@ -22,9 +22,9 @@ import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
-import com.vladsch.flexmark.ast.Node;
 import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.options.MutableDataSet;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.data.MutableDataSet;
 
 /**
  * Checks the README.md files for:

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
@@ -22,10 +22,10 @@ import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ast.Image;
 import com.vladsch.flexmark.ast.ListBlock;
 import com.vladsch.flexmark.ast.ListItem;
-import com.vladsch.flexmark.ast.Node;
-import com.vladsch.flexmark.ast.NodeVisitorBase;
 import com.vladsch.flexmark.ast.OrderedList;
 import com.vladsch.flexmark.ast.Paragraph;
+import com.vladsch.flexmark.util.ast.Node;
+import com.vladsch.flexmark.util.ast.NodeVisitorBase;
 
 /**
  * This visitor processes headers, lists and code sections and logs errors when

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <pde.core.version>3.11.1</pde.core.version>
     <sat.version>0.10.0</sat.version>
     <jdt-annotations.version>2.1.0</jdt-annotations.version>
-    <flexmark.version>0.28.6</flexmark.version>
+    <flexmark.version>0.60.0</flexmark.version>
     <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
     <jetty.server.version>9.4.20.v20190813</jetty.server.version>
     <saxon.version>9.1.0.8</saxon.version>


### PR DESCRIPTION
Upgrades flexmark from 0.28.6 to 0.60.0.

For release notes, see:

https://github.com/vsch/flexmark-java/blob/master/VERSION.md