### PR TITLE
Upgrade Checkstyle to 8.45.1

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -54,7 +54,7 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
     public void setUp() {
         lineNumberToWarningMessageExpected = new TreeMap<>();
         configuration = createModuleConfig(AuthorContributionDescriptionCheck.class);
-        configuration.addAttribute(ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME, ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE);
+        configuration.addProperty(ATTRIBUTE_REQUIRED_DESCRIPTIONS_NAME, ATTRIBUTE_REQUIRED_DESCRIPTIONS_VALUE);
     }
 
     /*
@@ -290,7 +290,7 @@ public class AuthorContributionDescriptionCheckTest extends AbstractStaticCheckT
                     .toArray(size -> new String[lineNumberToWarningMessageExpected.size()]);
         }
 
-        configuration.addAttribute(ATTRIBUTE_CHECK_UNITS_NAME, String.valueOf(checkInnerUnits));
+        configuration.addProperty(ATTRIBUTE_CHECK_UNITS_NAME, String.valueOf(checkInnerUnits));
         verify(configuration, filePath, expected);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
@@ -115,10 +115,10 @@ public class AuthorTagCheckTest extends AbstractStaticCheckTest {
          * should be the same as their corresponding properties defined in
          * rulesets.checkstyle/rules.xml file
          */
-        configuration.addAttribute("tag", "@author");
-        configuration.addAttribute("tagFormat", "\\S");
-        configuration.addAttribute("tagSeverity", "ignore");
-        configuration.addAttribute("checkInnerUnits", String.valueOf(checkInnerUnits));
+        configuration.addProperty("tag", "@author");
+        configuration.addProperty("tagFormat", "\\S");
+        configuration.addProperty("tagSeverity", "ignore");
+        configuration.addProperty("checkInnerUnits", String.valueOf(checkInnerUnits));
         configuration.addMessage("type.missingTag", EXPECTED_WARNING_MESSAGE);
 
         return configuration;

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
@@ -50,9 +50,9 @@ public class BuildPropertiesCheckTest extends AbstractStaticCheckTest {
 
     @BeforeAll
     public static void setUpTest() {
-        config.addAttribute("expectedBinIncludesValues", "META-INF/");
-        config.addAttribute("possibleOutputValues", "target/classes,target/test-classes");
-        config.addAttribute("possibleSourceValues", "src/main/java,src/main/resources,src/test/java,src/test/groovy");
+        config.addProperty("expectedBinIncludesValues", "META-INF/");
+        config.addProperty("possibleOutputValues", "target/classes,target/test-classes");
+        config.addProperty("possibleSourceValues", "src/main/java,src/main/resources,src/test/java,src/test/groovy");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
@@ -29,7 +29,7 @@ public class BundleVendorCheckTest extends AbstractStaticCheckTest {
 
     @BeforeAll
     public static void setUpClass() {
-        CHECK_CONFIG.addAttribute("allowedValues", "openHAB");
+        CHECK_CONFIG.addProperty("allowedValues", "openHAB");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
@@ -31,8 +31,8 @@ public class ForbiddenPackageUsageCheckTest extends AbstractStaticCheckTest {
 
     @BeforeEach
     public void setUp() {
-        config.addAttribute("forbiddenPackages", "com.google.common,com.something.something,org.something.asd");
-        config.addAttribute("exceptions", "com.google.common.utils");
+        config.addProperty("forbiddenPackages", "com.google.common,com.something.something,org.something.asd");
+        config.addProperty("exceptions", "com.google.common.utils");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
@@ -48,7 +48,7 @@ public class KarafAddonFeatureCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testExcludeAddonPatterns() throws Exception {
         DefaultConfiguration config = createModuleConfig(KarafAddonFeatureCheck.class);
-        config.addAttribute("excludeAddonPatterns", "excludeAddon.*");
+        config.addProperty("excludeAddonPatterns", "excludeAddon.*");
 
         verify(config, getPath("excludeAddonPatterns" + File.separator + POM_XML_FILE_NAME),
                 ArrayUtils.EMPTY_STRING_ARRAY);
@@ -84,7 +84,7 @@ public class KarafAddonFeatureCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testPatternFeatureName() throws Exception {
         DefaultConfiguration config = createModuleConfig(KarafAddonFeatureCheck.class);
-        config.addAttribute("featureNameMappings", "openhab-binding-example:org.openhab.binding.someother");
+        config.addProperty("featureNameMappings", "openhab-binding-example:org.openhab.binding.someother");
         verify(config, getPath("invalidFeatureName" + File.separator + FEATURE_XML_PATH),
                 ArrayUtils.EMPTY_STRING_ARRAY);
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
@@ -44,7 +44,7 @@ public class KarafFeatureCheckTest extends AbstractStaticCheckTest {
 
     @BeforeAll
     public static void setUp() {
-        CONFIGURATION.addAttribute("featureXmlPath", "feature/feature.xml:feature/internal/feature.xml");
+        CONFIGURATION.addProperty("featureXmlPath", "feature/feature.xml:feature/internal/feature.xml");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
@@ -30,7 +30,7 @@ public class ManifestJavaVersionCheckTest extends AbstractStaticCheckTest {
 
     @BeforeAll
     public static void setUpClass() {
-        CHECK_CONFIG.addAttribute("allowedValues", "JavaSE-1.8");
+        CHECK_CONFIG.addProperty("allowedValues", "JavaSE-1.8");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
@@ -39,8 +39,8 @@ public class ManifestPackageVersionCheckTest extends AbstractStaticCheckTest {
     @BeforeAll
     public static void createConfiguration() {
         config = createModuleConfig(ManifestPackageVersionCheck.class);
-        config.addAttribute("ignoreImportedPackages", "org.apache.*, org.junit.*");
-        config.addAttribute("ignoreExportedPackages", "org.openhab.core.tool.*");
+        config.addProperty("ignoreImportedPackages", "org.apache.*, org.junit.*");
+        config.addProperty("ignoreExportedPackages", "org.openhab.core.tool.*");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
@@ -34,14 +34,14 @@ public class MissingJavadocFilterCheckTest extends AbstractStaticCheckTest {
 
     @Test
     public void testOuterClassWithJavadoc() throws Exception {
-        int[] lineNumbers = new int[] { 10 };
-        verifyJavadoc("MissingJavadocOuterAndInnnerClass.java", false, lineNumbers);
+        String[] locations = new String[] { "10:1" };
+        verifyJavadoc("MissingJavadocOuterAndInnnerClass.java", false, locations);
     }
 
     @Test
     public void testOuterAndInnerClassesWithJavadoc() throws Exception {
-        int[] lineNumbers = new int[] { 10, 12 };
-        verifyJavadoc("MissingJavadocOuterAndInnnerClass.java", true, lineNumbers);
+        String[] locations = new String[] { "10:1", "12:5" };
+        verifyJavadoc("MissingJavadocOuterAndInnnerClass.java", true, locations);
     }
 
     @Test
@@ -54,18 +54,18 @@ public class MissingJavadocFilterCheckTest extends AbstractStaticCheckTest {
         verifyJavadoc("PresentJavadocOuterAndInnerClass.java", true, null);
     }
 
-    private void verifyJavadoc(String testFileName, boolean checkInnerClasses, int[] lineNumbers) throws Exception {
+    private void verifyJavadoc(String testFileName, boolean checkInnerClasses, String[] locations) throws Exception {
         DefaultConfiguration config = createModuleConfig(MissingJavadocFilterCheck.class);
         String checkInnerClassesPropertyName = "checkInnerUnits";
-        config.addAttribute(checkInnerClassesPropertyName, String.valueOf(checkInnerClasses));
+        config.addProperty(checkInnerClassesPropertyName, String.valueOf(checkInnerClasses));
 
         String filePath = getPath(testFileName);
 
         String[] expectedMessages = null;
-        if (lineNumbers != null) {
-            expectedMessages = new String[lineNumbers.length];
-            for (int i = 0; i < lineNumbers.length; i++) {
-                expectedMessages[i] = lineNumbers[i] + ": " + JavadocStyleCheck.MSG_JAVADOC_MISSING;
+        if (locations != null) {
+            expectedMessages = new String[locations.length];
+            for (int i = 0; i < locations.length; i++) {
+                expectedMessages[i] = locations[i] + ": " + JavadocStyleCheck.MSG_JAVADOC_MISSING;
             }
         } else {
             expectedMessages = CommonUtil.EMPTY_STRING_ARRAY;

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
@@ -146,7 +146,7 @@ public class NullAnnotationsCheckTest extends AbstractStaticCheckTest {
 
     private void checkFile(String fileName, boolean checkInnerUnits, String... expectedMessages) throws Exception {
         String filePath = getPath(fileName);
-        configuration.addAttribute(ATTRIBUTE_NAME, String.valueOf(checkInnerUnits));
+        configuration.addProperty(ATTRIBUTE_NAME, String.valueOf(checkInnerUnits));
         verify(configuration, filePath, expectedMessages);
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
@@ -45,7 +45,7 @@ public class OhInfXmlLabelCheckTest extends AbstractStaticCheckTest {
     @Before
     public void before() {
         configuration = createModuleConfig(OhInfXmlLabelCheck.class);
-        configuration.addAttribute("checkWordCasing", "true");
+        configuration.addProperty("checkWordCasing", "true");
     }
 
     @Override
@@ -115,7 +115,7 @@ public class OhInfXmlLabelCheckTest extends AbstractStaticCheckTest {
         final String[] expectedMessages = generateExpectedMessages(16,
                 MessageFormat.format(String.format(OhInfXmlLabelCheck.MESSAGE_MAX_LABEL_LENGTH, 25), "thing-type", "id",
                         "check", "L" + "o".repeat(21) + "ng Label", 30));
-        configuration.addAttribute("maxLabelLength", "25");
+        configuration.addProperty("maxLabelLength", "25");
         verifyWithPath("exceedsMaxLabelLength", RELATIVE_PATH_TO_THING, expectedMessages);
     }
 

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.tools.analysis.checkstyle.test;
 
-import static org.junit.jupiter.api.Assumptions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.OH_INF_PATH;
 
 import java.io.File;
@@ -59,9 +59,9 @@ public class OhInfXmlValidationCheckTest extends AbstractStaticCheckTest {
 
     @BeforeAll
     public static void createConfiguration() {
-        CONFIGURATION.addAttribute("thingSchema", THING_SCHEMA_URL);
-        CONFIGURATION.addAttribute("bindingSchema", BINDING_SCHEMA_URL);
-        CONFIGURATION.addAttribute("configSchema", CONFIG_SCHEMA_URL);
+        CONFIGURATION.addProperty("thingSchema", THING_SCHEMA_URL);
+        CONFIGURATION.addProperty("bindingSchema", BINDING_SCHEMA_URL);
+        CONFIGURATION.addProperty("configSchema", CONFIG_SCHEMA_URL);
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
@@ -36,7 +36,7 @@ public class OnlyTabIndentationCheckTest extends AbstractStaticCheckTest {
     @BeforeEach
     public void setUpClass() {
         config = createModuleConfig(OnlyTabIndentationCheck.class);
-        config.addAttribute("fileTypes", "xml,json");
+        config.addProperty("fileTypes", "xml,json");
     }
 
     @Override
@@ -140,9 +140,9 @@ public class OnlyTabIndentationCheckTest extends AbstractStaticCheckTest {
         String testFileAbsolutePath = getPath(fileName);
         String messageFilePath = testFileAbsolutePath;
         if (onlyShowFirstWarning) {
-            config.addAttribute("onlyShowFirstWarning", "true");
+            config.addProperty("onlyShowFirstWarning", "true");
         } else {
-            config.addAttribute("onlyShowFirstWarning", "false");
+            config.addProperty("onlyShowFirstWarning", "false");
         }
         verify(createChecker(config), testFileAbsolutePath, messageFilePath, expectedMessages);
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
@@ -42,7 +42,7 @@ public class OutsideOfLibExternalLibrariesCheckTest extends AbstractStaticCheckT
         config = createModuleConfig(OutsideOfLibExternalLibrariesCheck.class);
 
         String ignoredDirectoriesValue = "bin,target";
-        config.addAttribute("ignoredDirectories", ignoredDirectoriesValue);
+        config.addProperty("ignoredDirectories", ignoredDirectoriesValue);
     }
 
     @Test

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
@@ -41,8 +41,8 @@ public class PackageExportsNameCheckTest extends AbstractStaticCheckTest {
     @BeforeAll
     public static void createConfiguration() {
         configuration = createModuleConfig(PackageExportsNameCheck.class);
-        configuration.addAttribute("sourceDirectories", "src/main/java");
-        configuration.addAttribute("excludedPackages", ".*.internal.*");
+        configuration.addProperty("sourceDirectories", "src/main/java");
+        configuration.addProperty("excludedPackages", ".*.internal.*");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
@@ -95,13 +95,13 @@ public class ParameterizedRegexpHeaderCheckTest extends AbstractStaticCheckTest 
     private DefaultConfiguration createTestConfiguration(String headerPattern, String values, String headerFormat) {
         DefaultConfiguration configuration = createModuleConfig(ParameterizedRegexpHeaderCheck.class);
         if (headerPattern != null) {
-            configuration.addAttribute("header", headerPattern);
+            configuration.addProperty("header", headerPattern);
         }
         if (values != null) {
-            configuration.addAttribute("values", values);
+            configuration.addProperty("values", values);
         }
         if (headerFormat != null) {
-            configuration.addAttribute("headerFormat", headerFormat);
+            configuration.addProperty("headerFormat", headerFormat);
         }
         return configuration;
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -50,7 +50,7 @@ public class PomXmlCheckTest extends AbstractStaticCheckTest {
     @BeforeAll
     public static void setUpClass() {
         config = createModuleConfig(PomXmlCheck.class);
-        config.addAttribute("checkPomVersion", "true");
+        config.addProperty("checkPomVersion", "true");
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -40,7 +40,7 @@ public class RequireBundleCheckTest extends AbstractStaticCheckTest {
         config = createModuleConfig(RequireBundleCheck.class);
 
         String allowedRequireBundles = String.format("%s,%s,%s", "org.junit", "org.hamcrest", "org.mockito");
-        config.addAttribute("allowedRequireBundles", allowedRequireBundles);
+        config.addProperty("allowedRequireBundles", allowedRequireBundles);
     }
 
     @Override

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
@@ -50,11 +50,11 @@ public class RequiredFilesCheckTest extends AbstractStaticCheckTest {
 
         String extenstionsPropertyValue = String.format("%s,%s,%s,%s,%s", HTML_EXTENSION, PROPERTIES_EXTENSION,
                 XML_EXTENSION, MANIFEST_EXTENSION, MARKDONW_EXTENSION);
-        config.addAttribute("extensions", extenstionsPropertyValue);
+        config.addProperty("extensions", extenstionsPropertyValue);
 
         String requiredFilesPropertyValue = String.format("%s,%s,%s,%s", BUILD_PROPERTIES_FILE_NAME, POM_XML_FILE_NAME,
                 MANIFEST_RELATIVE_PATH_NAME, README_MD_FILE_NAME);
-        config.addAttribute("requiredFiles", requiredFilesPropertyValue);
+        config.addProperty("requiredFiles", requiredFilesPropertyValue);
     }
 
     @Override

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -100,7 +100,7 @@ Parameters:
 | ------ | ------| -------- |
 | **checkstyleRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **checkstyleFilter** | String | Relative path of the suppressions XML file to use. If not set the default filter file will be used |
-| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.1.1**)|
+| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.1.2**)|
 | **checkstylePlugins** | List<Dependency> | A list with artifacts that contain additional checks for Checkstyle |
 | **checkstyleProperties** | String | Relative path of the properties file to use in the ruleset to configure specific checks |
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <mockito.version>3.7.0</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
     <pmd.version>6.22.0</pmd.version>
-    <checkstyle.version>8.30</checkstyle.version>
+    <checkstyle.version>8.45.1</checkstyle.version>
     <spotbugs.version>4.0.1</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
@@ -128,10 +128,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <!-- Checkstyle classes such as AbstractModuleTestSupport still use JUnit 4 imports -->
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit.version}</version>
+      <!-- Required for Checkstyle tests -->
+      <groupId>com.google.truth</groupId>
+      <artifactId>truth</artifactId>
+      <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -53,7 +53,7 @@ public class CheckstyleChecker extends AbstractChecker {
     /**
      * The version of the maven-checkstyle-plugin that will be used
      */
-    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.1.1")
+    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.1.2")
     private String checkstyleMavenVersion;
 
     /**
@@ -118,7 +118,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "8.30"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "8.45.1"));
         checkstylePlugins.forEach(logDependency());
 
         String baseDir = mavenProject.getBasedir().toString();


### PR DESCRIPTION
Upgrades Checkstyle from 8.30 to 8.45.1.

For release notes, see:

https://checkstyle.sourceforge.io/releasenotes.html