### PR TITLE
Upgrade PMD to 6.39.0

### DIFF
--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -86,7 +86,7 @@ Parameters:
 | ------ | ------| -------- |
 | **pmdRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **pmdFilter** | String | Relative path of a suppression.properties file that lists classes and rules to be excluded from failures. If not set no classes and no rules will be excluded |
-| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.13.0**)|
+| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.15.0**)|
 | **pmdPlugins** | List<Dependency> | A list with artifacts that contain additional checks for PMD |
 
 ### sat-plugin:checkstyle

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <commons.lang.version>2.6</commons.lang.version>
     <mockito.version>3.7.0</mockito.version>
     <maven.resources.version>2.4</maven.resources.version>
-    <pmd.version>6.22.0</pmd.version>
+    <pmd.version>6.39.0</pmd.version>
     <checkstyle.version>8.30</checkstyle.version>
     <spotbugs.version>4.0.1</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -60,7 +60,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.13.0")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.15.0")
     private String mavenPmdVersion;
 
     /**
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "6.22.0";
+    private static final String PMD_VERSION = "6.39.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */

--- a/sat-plugin/src/main/resources/rulesets/pmd/customrules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/customrules.xml
@@ -2,7 +2,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
 	<description>Rule set that contains custom rules created for checking all bundles</description>
-	<rule class="org.openhab.tools.analysis.pmd.UseSLF4JLoggerRule" name="UseSLF4J"
+	<rule class="org.openhab.tools.analysis.pmd.UseSLF4JLoggerRule" name="UseSLF4J" language="java"
 		message="The org.slf4j Logger should be used">
 		<priority>3</priority>
 	</rule>

--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -6,11 +6,11 @@
 	<description>Default set of PMD rules used for checking all bundles</description>
 
 	<rule ref="category/java/errorprone.xml/EmptyIfStmt">
-		<!-- See https://pmd.github.io/pmd-6.7.0/pmd_rules_java_errorprone.html for all below -->
+		<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_errorprone.html for all below -->
 		<!-- Priorities range in value from 1 to 5, with 5 being the lowest priority -->
 		<!-- We will use only priority 1,2 and 3 so the results of PMD can be comparable with the results of the other tools -->
 
-		<!-- See http://pmd.github.io/pmd-5.0.1/apidocs/net/sourceforge/pmd/RulePriority.html -->
+		<!-- See https://docs.pmd-code.org/apidocs/pmd-core/6.39.0/net/sourceforge/pmd/RulePriority.html -->
 		<priority>3</priority>
 	</rule>
 	<rule ref="category/java/errorprone.xml/EmptyWhileStmt">
@@ -71,7 +71,7 @@
 		<priority>2</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.7.0/pmd_rules_java_multithreading.html -->
+	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_multithreading.html -->
 	<rule ref="category/java/multithreading.xml/DontCallThreadRun">
 		<priority>2</priority>
 	</rule>
@@ -92,7 +92,7 @@
 	</rule>
 
 
-	<!-- See https://pmd.github.io/pmd-6.7.0/pmd_rules_java_bestpractices.html -->
+	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_bestpractices.html -->
 	<rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
 		<priority>1</priority>
 	</rule>
@@ -100,7 +100,7 @@
 		<priority>2</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.7.0/pmd_rules_java_design.html -->
+	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_design.html -->
 	<rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes">
 		<priority>2</priority>
 	</rule>
@@ -117,7 +117,7 @@
 		<priority>3</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.7.0/pmd_rules_java_performance.html -->
+	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_performance.html -->
 	<rule ref="category/java/performance.xml/AvoidArrayLoops">
 		<priority>3</priority>
 	</rule>


### PR DESCRIPTION
Upgrades PMD from 6.22.0 to 6.39.0

For release notes, see:

* https://pmd.github.io/pmd-6.39.0/pmd_release_notes.html
* https://pmd.github.io/pmd-6.39.0/pmd_release_notes_old.html