### PR TITLE
Update license headers to 2022

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AnnotationDependencyCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AnnotationDependencyCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorTagCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorTagCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AvoidScheduleAtFixedRateCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AvoidScheduleAtFixedRateCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesExternalLibrariesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BuildPropertiesExternalLibrariesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BundleVendorCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/BundleVendorCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/DeclarativeServicesDependencyInjectionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/DeclarativeServicesDependencyInjectionCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ExportInternalPackageCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ImportExportedPackagesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/InheritDocCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/InheritDocCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafFeatureCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafFeatureCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestExternalLibrariesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestExternalLibrariesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestJavaVersionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestJavaVersionCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestLineLengthCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestLineLengthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestPackageVersionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ManifestPackageVersionCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/MissingJavadocFilterCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/MissingJavadocFilterCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlLabelCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlLabelCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlValidationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlValidationCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OutsideOfLibExternalLibrariesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PackageExportsNameCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PackageExportsNameCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequireBundleCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequiredFilesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequiredFilesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ServiceComponentManifestCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ServiceComponentManifestCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractExternalLibrariesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractExternalLibrariesCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractManifestAttributeCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractManifestAttributeCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractOhInfXmlCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractOhInfXmlCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/NoResultException.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/NoResultException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/CachingHttpClient.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/CachingHttpClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/ContentReceviedCallback.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/ContentReceviedCallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/SatCheckUtils.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/SatCheckUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AnnotationDependencyCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BuildPropertiesExternalLibrariesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/BundleVendorCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ExportInternalPackageCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ImportExportedPackagesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/LoggedMessagesExtension.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/LoggedMessagesExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestExternalLibrariesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestJavaVersionCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestLineLengthCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestLineLengthCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ManifestPackageVersionCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OutsideOfLibExternalLibrariesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PackageExportsNameCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequireBundleCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ServiceComponentManifestCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ServiceComponentManifestCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/export/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/export/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/internal/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/internal/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/storage/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/excluded_packages/src/main/java/org/openhab/storage/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/core/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/core/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/test/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/test/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/test/storage/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/groovy/org/openhab/test/storage/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/core/export/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/core/export/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/internal/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/internal/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/not/exported/package/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_exported_packages/src/main/java/org/openhab/not/exported/package/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_included_source_directories/src/main/groovy/org/openhab/test/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_included_source_directories/src/main/groovy/org/openhab/test/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_included_source_directories/src/main/groovy/org/openhab/test/storage/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/not_included_source_directories/src/main/groovy/org/openhab/test/storage/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/core/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/core/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/test/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/test/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/test/storage/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/groovy/org/openhab/test/storage/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/core/export1/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/core/export1/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/core/export2/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/core/export2/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/internal/TestFile.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/packageExportsNameCheckTest/valid_exports/src/main/java/org/openhab/internal/TestFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/correctly_included_services_in_manifest/OSGI-INF/serviceTestFileOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/correctly_included_services_in_manifest/OSGI-INF/serviceTestFileOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/correctly_included_services_in_manifest/OSGI-INF/serviceTestFileTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/correctly_included_services_in_manifest/OSGI-INF/serviceTestFileTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/explicitly_included_services_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/explicitly_included_services_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/explicitly_included_services_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/explicitly_included_services_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_all_services_in_build_properties/OSGI-INF/serviceTestFileOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_all_services_in_build_properties/OSGI-INF/serviceTestFileOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_all_services_in_build_properties/OSGI-INF/serviceTestFileTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_all_services_in_build_properties/OSGI-INF/serviceTestFileTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_component_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_component_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_component_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_component_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_in_build_properties/OSGI-INF/serviceTestFileOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_in_build_properties/OSGI-INF/serviceTestFileOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_in_build_properties/OSGI-INF/serviceTestFileTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/missing_service_in_build_properties/OSGI-INF/serviceTestFileTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceThree.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceThree.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/non_existent_service_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceThree.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceThree.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_included_services_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_matching_regex_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_matching_regex_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_matching_regex_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/not_matching_regex_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/regex_included_service_in_manifest/OSGI-INF/testServiceOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/regex_included_service_in_manifest/OSGI-INF/testServiceOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/regex_included_service_in_manifest/OSGI-INF/testServiceTwo.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/regex_included_service_in_manifest/OSGI-INF/testServiceTwo.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/repeated_service_in_manifest/OSGI-INF/service.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/repeated_service_in_manifest/OSGI-INF/service.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/wildcard_only_in_manifest/OSGI-INF/serviceTestFileOne.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/serviceComponentManifestCheckTest/wildcard_only_in_manifest/OSGI-INF/serviceTestFileOne.xml
@@ -1,6 +1,6 @@
 <!--
 
-	Copyright (c) 2010-2021 Contributors to the openHAB project
+	Copyright (c) 2010-2022 Contributors to the openHAB project
 
 	See the NOTICE file(s) distributed with this work for additional
 	information.

--- a/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
+++ b/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/CustomRulesTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/CustomRulesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,7 @@
               <exclude>target/**</exclude>
               <exclude>**/org/openhab/tools/analysis/findbugs/CustomClassNameLengthDetector.java</exclude>
               <exclude>**/org/openhab/tools/analysis/report/ReportUtility.java</exclude>
+              <exclude>**/org/openhab/tools/analysis/report/ReportMojo.java</exclude>
             </excludes>
             <useDefaultExcludes>true</useDefaultExcludes>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
             </excludes>
             <useDefaultExcludes>true</useDefaultExcludes>
             <properties>
-              <year>2021</year>
+              <year>2022</year>
             </properties>
             <encoding>UTF-8</encoding>
           </configuration>

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportExecutionListener.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportExecutionListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportHtmlGenerator.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportHtmlGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportLifecycleParticipant.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportLifecycleParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportMojo.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportMojo.java
@@ -1,37 +1,14 @@
 /**
- * Copyright (C) 2012-2013, Markus Sprunck
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
- * All rights reserved.
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
  *
- * Redistribution and use in source and binary forms, with or
- * without modification, are permitted provided that the following
- * conditions are met:
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
  *
- * - Redistributions of source code must retain the above copyright
- *   notice, this list of conditions and the following disclaimer.
- *
- * - Redistributions in binary form must reproduce the above
- *   copyright notice, this list of conditions and the following
- *   disclaimer in the documentation and/or other materials provided
- *   with the distribution.
- *
- * - The name of its contributor may be used to endorse or promote
- *   products derived from this software without specific prior
- *   written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
- * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
- * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
- * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
- * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
- * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.tools.analysis.report;
 

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportMojo.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportMojo.java
@@ -1,14 +1,37 @@
 /**
- * Copyright (c) 2010-2022 Contributors to the openHAB project
+ * Copyright (C) 2012-2013, Markus Sprunck
  *
- * See the NOTICE file(s) distributed with this work for additional
- * information.
+ * All rights reserved.
  *
- * This program and the accompanying materials are made available under the
- * terms of the Eclipse Public License 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
  *
- * SPDX-License-Identifier: EPL-2.0
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - The name of its contributor may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.openhab.tools.analysis.report;
 

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtil.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/SummaryHtmlGeneration.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/SummaryHtmlGeneration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/internal/SpotBugsVisitors.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/internal/SpotBugsVisitors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/sat-plugin/src/test/java/org/openhab/tools/analysis/report/ReportMojoTest.java
+++ b/sat-plugin/src/test/java/org/openhab/tools/analysis/report/ReportMojoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010-2021 Contributors to the openHAB project
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information.

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,7 +1,7 @@
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time,org.junit.Assert,org.junit.Test,si.uom,tech.units
 checkstyle.forbiddenPackageUsageCheck.exceptions=
 checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
-checkstyle.headerCheck.values=2010,2021
+checkstyle.headerCheck.values=2010,2022
 checkstyle.requiredFilesCheck.extensions=xml,md
 checkstyle.requiredFilesCheck.files=pom.xml
 


### PR DESCRIPTION
- Update license headers to 2022

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>