### PR TITLE
Allow `@NonNull` on generic argument and parameter types

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
@@ -154,8 +154,31 @@ public class NullAnnotationsCheck extends AbstractCheck {
     private void checkForNonNullAnnotation(DetailAST ast) {
         DetailAST atClause = CheckUtil.getFirstNode(ast);
         String annotationName = atClause.getNextSibling().getText();
-        if (NONNULL_ANNOTATION.equals(annotationName) && imports.contains(NonNull.class.getName())) {
+        if (NONNULL_ANNOTATION.equals(annotationName) && imports.contains(NonNull.class.getName()) && !isGeneric(ast)) {
             log(atClause.getLineNo(), WARNING_MESSAGE_NONNULL_ANNOTATION);
         }
+    }
+
+    /**
+     * Method that checks if the annotation is on a generic argument or parameter type
+     *
+     * @param ast the ast
+     */
+    private boolean isGeneric(DetailAST ast) {
+        for (DetailAST parentAst = ast.getParent(); parentAst != null; parentAst = parentAst.getParent()) {
+            int type = parentAst.getType();
+            if (type == TokenTypes.TYPE_ARGUMENT || type == TokenTypes.TYPE_PARAMETER) {
+                for (DetailAST siblingAst = parentAst.getPreviousSibling(); siblingAst != null; siblingAst = siblingAst
+                        .getPreviousSibling()) {
+                    type = siblingAst.getType();
+                    if (type == TokenTypes.GENERIC_START) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
@@ -96,7 +96,7 @@ public class NullAnnotationsCheckTest extends AbstractStaticCheckTest {
     @Test
     public void testGenericsWithNonNullAnnotation() throws Exception {
         String fileName = "GenericsNonNullAnnotation.java";
-        String[] expectedMessage = generateExpectedMessages(9, EXPECTED_WARNING_MESSAGE_NONNULL_ANNOTATION);
+        String[] expectedMessage = generateExpectedMessages(14, EXPECTED_WARNING_MESSAGE_NONNULL_ANNOTATION);
         boolean checkInnerUnits = false;
         checkFile(fileName, checkInnerUnits, expectedMessage);
     }

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/nullAnnotationsCheckTest/GenericsNonNullAnnotation.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/nullAnnotationsCheckTest/GenericsNonNullAnnotation.java
@@ -2,12 +2,28 @@ package checkstyle.nullAnnotationsCheckTest;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 
 @NonNullByDefault
-public class GenericsNonNullAnnotation {
-    
-    public @NonNull List<@NonNull Class<? extends State>> getAcceptedDataTypes() {
+public class GenericsNonNullAnnotation<@Nullable U, @NonNull V> {
+
+    public @Nullable List<@NonNull Class<? extends State>> getNullableAcceptedDataTypes() {
         return Collections.emptyList();
     }
 
+    public @NonNull List<@NonNull Class<? extends State>> getNonNullAcceptedDataTypes() {
+        return Collections.emptyList();
+    }
+
+    public <@NonNull T> T getAsType(Class<T> type, Object object) {
+        return (T) object;
+    }
+
+    public U getAsTypeU(@Nullable Object object) {
+        return (U) object;
+    }
+
+    public V getAsTypeV(Object object) {
+        return (V) object;
+    }
 }


### PR DESCRIPTION
When classes are annotated with `@NonNullByDefault` this annotation does not apply to generic argument and parameter types.
With these changes the `NullAnnotationsCheck` allows for `@NonNull` annotations on generic argument and parameter types.

This fixes for instance 48 `NullAnnotationsCheck` false positives in openhab-core and makes it easier to find and fix real `@NonNull` misusages.