### PR TITLE
Fix OhInfXmlUsageCheck configurable service unused configuration false positives

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
@@ -39,6 +39,8 @@ public class CheckConstants {
 
     // Directory names
     public static final String OSGI_INF_DIRECTORY_NAME = "OSGI-INF";
+    public static final String OSGI_INF_PATH = Path.of("target", "classes", OSGI_INF_DIRECTORY_NAME).toString();
+
     public static final String META_INF_DIRECTORY_NAME = "META-INF";
     public static final String OH_INF_DIRECTORY = "OH-INF";
     public static final String OH_INF_PATH = Path.of("src", "main", "resources", OH_INF_DIRECTORY).toString();

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
@@ -17,6 +17,7 @@ import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.OH_INF_PA
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.openhab.tools.analysis.checkstyle.OhInfXmlUsageCheck;
@@ -51,6 +52,11 @@ public class OhInfXmlUsageCheckTest extends AbstractStaticCheckTest {
     }
 
     @Test
+    public void testConfigurableService() throws Exception {
+        verifyWithPath("configurableService", RELATIVE_PATH_TO_THING, new String[0]);
+    }
+
+    @Test
     public void testMissingSupportedBridgeRef() throws Exception {
         String[] expectedMessages = generateExpectedMessages(0,
                 MessageFormat.format(MESSAGE_MISSING_SUPPORTED_BRIDGE, "bridge"));
@@ -82,11 +88,11 @@ public class OhInfXmlUsageCheckTest extends AbstractStaticCheckTest {
         String directoryPath = getPath(testSubDirectory);
         File testDirectoryPath = new File(directoryPath);
 
-        File[] testFiles = listFilesForFolder(testDirectoryPath, new ArrayList<File>());
+        File[] testFiles = listFilesForFolder(testDirectoryPath, new ArrayList<>());
         verify(createChecker(CONFIGURATION), testFiles, directoryPath + testFilePath, expectedMessages);
     }
 
-    private File[] listFilesForFolder(File folder, ArrayList<File> files) {
+    private File[] listFilesForFolder(File folder, List<File> files) {
         for (File fileEntry : folder.listFiles()) {
             if (fileEntry.isDirectory()) {
                 listFilesForFolder(fileEntry, files);

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/configurableService/src/main/resources/OH-INF/config/addons.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/configurableService/src/main/resources/OH-INF/config/addons.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+		https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="system:addons">
+		<parameter name="remote" type="boolean" required="true">
+			<label>Access Remote Repository</label>
+			<description>Defines whether openHAB should access the remote repository for add-on installation.</description>
+			<default>true</default>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/configurableService/target/classes/OSGI-INF/org.openhab.addons.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/configurableService/target/classes/OSGI-INF/org.openhab.addons.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.4.0" name="org.openhab.addons" activate="activate" deactivate="deactivate" modified="modified" init="2">
+  <property name="service.config.category" type="String" value="system"/>
+  <property name="service.config.label" type="String" value="Add-on Management"/>
+  <property name="service.config.description.uri" type="String" value="system:addons"/>
+  <property name="service.config.factory" type="Boolean" value="false"/>
+  <service>
+    <provide interface="org.openhab.core.karaf.internal.FeatureInstaller"/>
+    <provide interface="org.osgi.service.cm.ConfigurationListener"/>
+  </service>
+  <reference name="$000" interface="org.osgi.service.cm.ConfigurationAdmin" parameter="0"/>
+  <reference name="$001" interface="org.apache.karaf.features.FeaturesService" parameter="1"/>
+  <reference name="EventPublisher" interface="org.openhab.core.events.EventPublisher" bind="setEventPublisher" unbind="unsetEventPublisher"/>
+  <implementation class="org.openhab.core.karaf.internal.FeatureInstaller"/>
+</scr:component>


### PR DESCRIPTION
This fixes many "Unused configuration reference with uri - ..." OhInfXmlUsageCheck false positives of configurations used by configurable services.
When there are still unused configuration references, the check will now also take into account the "service.config.description.uri" properties in the generated XML of service components in the OSGI-INF dir.