### PR TITLE
Suppress OhInfXmlUsageCheck profile unused configuration false positives

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
@@ -69,6 +69,7 @@ public class OhInfXmlUsageCheck extends AbstractOhInfXmlCheck {
 
         // Check for unused referenced config descriptions
         Map<String, File> unusedConfigDescriptions = removeAll(allConfigDescriptions, allConfigDescriptionRefs);
+        unusedConfigDescriptions.keySet().removeIf(key -> key.startsWith("profile:"));
         if (!unusedConfigDescriptions.isEmpty()) {
             // Check if the unused config descriptions are referenced by configurable service components
             Map<String, File> configurableServiceRefs = getConfigurableServiceRefs(

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
@@ -71,6 +71,11 @@ public class OhInfXmlUsageCheckTest extends AbstractStaticCheckTest {
     }
 
     @Test
+    public void testProfileConfigDescription() throws Exception {
+        verifyWithPath("profileConfigDescription", RELATIVE_PATH_TO_THING, new String[0]);
+    }
+
+    @Test
     public void testUnusedConfig() throws Exception {
         String[] expectedMessages = generateExpectedMessages(0,
                 MessageFormat.format(MESSAGE_UNUSED_URI_CONFIGURATION, "thing-type:bindingID:thing"));

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/profileConfigDescription/src/main/resources/OH-INF/config/conf.xml
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/ohInfXmlUsageCheckTest/profileConfigDescription/src/main/resources/OH-INF/config/conf.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config-description:config-descriptions
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:config-description="https://openhab.org/schemas/config-description/v1.0.0"
+	xsi:schemaLocation="https://openhab.org/schemas/config-description/v1.0.0
+    https://openhab.org/schemas/config-description-1.0.0.xsd">
+
+	<config-description uri="profile:system:offset">
+		<parameter name="offset" type="text" required="true">
+			<label>Offset</label>
+			<description>Offset (plain number or number with unit) to be applied on the state towards the item. The negative offset will be applied in the reverse direction.</description>
+		</parameter>
+	</config-description>
+
+</config-description:config-descriptions>


### PR DESCRIPTION
Suppresses unused configuration reference warnings for configuration description URIs starting with "profile:".
Currently the only way to figure out what profile type UIDs are used in a bundle seems to be by instantiating each ProfileFactory.