### PR TITLE
MarkdownCheck improvements

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
@@ -16,8 +16,6 @@ import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
 
-import org.eclipse.pde.core.build.IBuild;
-import org.eclipse.pde.core.build.IBuildEntry;
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
@@ -34,50 +32,23 @@ import com.vladsch.flexmark.util.data.MutableDataSet;
  * <li>missing empty lines before and after lists.
  * </ul>
  *
- * Checks the build.properties for:
- * <ul>
- * <li>the README.MD shouldn't be added in build.properties.
- * <li>the doc folder shouldn't be added in build.properties.
- * </ul>
  * <a href="https://www.openhab.org/docs/developer/guidelines.html">openHAB Coding Guidelines</a>
  *
  * @author Erdoan Hadzhiyusein - Initial contribution
  * @author Lyubomir Papazov - Change the Markdown parser to flexmark
  */
 public class MarkdownCheck extends AbstractStaticCheck {
-    private static final String ADDED_README_FILE_IN_BUILD_PROPERTIES_MSG = "README.MD file must not be added to the bin.includes property";
-    private static final String ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG = "The doc folder must not be added to the bin.includes property";
-    private static final String DOC_FOLDER_NAME = "doc";
 
     public MarkdownCheck() {
-        setFileExtensions(MARKDONW_EXTENSION, PROPERTIES_EXTENSION);
+        setFileExtensions(MARKDONW_EXTENSION);
     }
 
     @Override
     protected void processFiltered(File file, FileText fileText) throws CheckstyleException {
         switch (file.getName()) {
-            case BUILD_PROPERTIES_FILE_NAME:
-                checkBuildProperties(fileText);
-                break;
             case README_MD_FILE_NAME:
                 checkReadMe(fileText);
                 break;
-        }
-    }
-
-    private void checkBuildProperties(FileText fileText) throws CheckstyleException {
-        // The check will not log an errors if build properties file is missing
-        // We have other check regarding this case - RequiredFilesCheck
-        IBuild buildPropertiesEntry = parseBuildProperties(fileText);
-        boolean isReadMeIncluded = checkBuildPropertiesEntry(buildPropertiesEntry, BIN_INCLUDES_PROPERTY_NAME,
-                README_MD_FILE_NAME);
-        if (isReadMeIncluded) {
-            log(0, ADDED_README_FILE_IN_BUILD_PROPERTIES_MSG);
-        }
-        boolean isDocFolderIncluded = checkBuildPropertiesEntry(buildPropertiesEntry, BIN_INCLUDES_PROPERTY_NAME,
-                DOC_FOLDER_NAME);
-        if (isDocFolderIncluded) {
-            log(0, ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG);
         }
     }
 
@@ -96,14 +67,5 @@ public class MarkdownCheck extends AbstractStaticCheck {
         };
         MarkdownVisitor visitor = new MarkdownVisitor(callBack, fileText);
         visitor.visit(readmeMarkdownNode);
-    }
-
-    /**
-     * Checks whether the given value is added in the build.properties file.
-     */
-    private boolean checkBuildPropertiesEntry(IBuild buildPropertiesFile, String property, String value)
-            throws CheckstyleException {
-        IBuildEntry binIncludes = buildPropertiesFile.getEntry(property);
-        return binIncludes != null && binIncludes.contains(value);
     }
 }

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
@@ -147,8 +147,13 @@ class MarkdownVisitor extends NodeVisitorBase {
         if (isListEnd) {
             String[] lastListItemlines = lastListItemContent.getChars().toString().split(REGEX_NEW_LINES);
             if (lastListItemlines.length > 1) {
-                // Log the one-based line where there is an empty line
-                callback.log(lastListItemContent.getLineNumber(), EMPTY_LINE_AFTER_LIST_MSG);
+                for (int i = 1; i < lastListItemlines.length; i++) {
+                    if (!lastListItemlines[i].startsWith(" ")) {
+                        // Log the one-based line where there is an empty line
+                        callback.log(lastListItemContent.getLineNumber(), EMPTY_LINE_AFTER_LIST_MSG);
+                        break;
+                    }
+                }
             }
         }
     }

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -16,7 +16,6 @@ import static com.puppycrawl.tools.checkstyle.utils.CommonUtil.EMPTY_STRING_ARRA
 import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.README_MD_FILE_NAME;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,8 +31,6 @@ import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
  * @author Lyubomir Papazov - Added more tests
  */
 public class MarkdownCheckTest extends AbstractStaticCheckTest {
-    private static final String ADDED_README_IN_BUILD_PROPERTIES_MSG = "README.MD file must not be added to the bin.includes property";
-    private static final String ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG = "The doc folder must not be added to the bin.includes property";
     private DefaultConfiguration config;
 
     @BeforeEach
@@ -84,6 +81,11 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     public void testEmptyLineAfterList() throws Exception {
         String[] expectedMessages = generateExpectedMessages(7, "The line after a Markdown list must be empty.");
         verifyMarkDownFile("testEmptyLineAfterList", expectedMessages);
+    }
+
+    @Test
+    public void testListWithParagraphs() throws Exception {
+        verifyMarkDownFile("testListWithParagraphs", noMessagesExpected());
     }
 
     @Test
@@ -226,40 +228,6 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     }
 
     @Test
-    public void testReadMeAddedInBuildProperties() throws Exception {
-        String[] expectedMessages = generateExpectedMessages(0, ADDED_README_IN_BUILD_PROPERTIES_MSG);
-        String testDirectoryName = "testAddedReadMeInBuildProperties";
-
-        // The message is logged for the build.properties file
-        verifyBuildProperties(expectedMessages, testDirectoryName);
-    }
-
-    @Test
-    public void testAddedDummyDocInBuildProperties() throws Exception {
-        String testDirectoryName = "testAddedDummyDocInBuildProperties";
-        verifyBuildProperties(noMessagesExpected(), testDirectoryName);
-    }
-
-    @Test
-    public void testDocFolderAddedInBuildProperties() throws Exception {
-        String[] expectedMessages = generateExpectedMessages(0, ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG);
-        String testDirectoryName = "testAddedDocFolderInBuildProperties";
-
-        // The message is logged for the build.properties file
-        verifyBuildProperties(expectedMessages, testDirectoryName);
-    }
-
-    @Test
-    public void testAddedReadmeAndDocInBuildProperties() throws Exception {
-        String[] expectedMessages = generateExpectedMessages(0, ADDED_README_IN_BUILD_PROPERTIES_MSG, 0,
-                ADDED_DOC_FOLDER_IN_BUILD_PROPERTIES_MSG);
-        String testDirectoryName = "testAddedReadmeAndDocInBuildProperties";
-
-        // The message is logged for the build.properties file
-        verifyBuildProperties(expectedMessages, testDirectoryName);
-    }
-
-    @Test
     public void testOpenhabBindingExec() throws Exception {
         String testDirectoryName = "org.openhab.binding.exec";
         verifyMarkDownFile(testDirectoryName, noMessagesExpected());
@@ -279,13 +247,6 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
     public void testDocFolderWrong() throws Exception {
         String[] expectedMessages = generateExpectedMessages(3, "Images must be located in the doc/ folder.");
         verifyMarkDownFile("testDocFolderWrong", expectedMessages);
-    }
-
-    private void verifyBuildProperties(String[] expectedMessages, String testDirectoryName)
-            throws IOException, Exception {
-        String testDirectoryAbsolutePath = getPath(testDirectoryName);
-        String messageFilePath = testDirectoryAbsolutePath + File.separator + "build.properties";
-        verify(createChecker(config), messageFilePath, expectedMessages);
     }
 
     private void createValidConfig() {

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDocFolderInBuildProperties/build.properties
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDocFolderInBuildProperties/build.properties
@@ -1,3 +1,0 @@
-output.. = target/classes/
-bin.includes = doc,\
-

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDummyDocInBuildProperties/build.properties
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDummyDocInBuildProperties/build.properties
@@ -1,4 +1,0 @@
-output.. = target/classes/
-bin.includes = dummydoc.txt,\
-               
-

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDummyDocInBuildProperties/dummydoc.txt
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedDummyDocInBuildProperties/dummydoc.txt
@@ -1,1 +1,0 @@
-this file is added in build_properties to test the check.

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadMeInBuildProperties/README.md
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadMeInBuildProperties/README.md
@@ -1,2 +1,0 @@
-# This is a README.md file
-

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadMeInBuildProperties/build.properties
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadMeInBuildProperties/build.properties
@@ -1,8 +1,0 @@
-output.. = target/classes/
-bin.includes = META-INF/,\
-               .,\
-               OSGI-INF/,\
-               OH-INF/,\
-               README.md
-source.. = src/main/java/,\
-           src/main/resources/

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadmeAndDocInBuildProperties/README.md
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadmeAndDocInBuildProperties/README.md
@@ -1,2 +1,0 @@
-# This is a README.md
-

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadmeAndDocInBuildProperties/build.properties
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testAddedReadmeAndDocInBuildProperties/build.properties
@@ -1,4 +1,0 @@
-output.. = target/classes/
-bin.includes = doc,\
-               README.md
-

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testListWithParagraphs/README.md
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testListWithParagraphs/README.md
@@ -1,0 +1,11 @@
+# Homematic Binding
+
+There are several settings for a bridge
+
+- **callbackHost** Callback network address 
+  of the openHAB server,
+  default is auto-discovery
+- **xmlCallbackPort**  
+  Callback port of the XML-RPC openHAB server,
+  default is 9125 and
+  counts up for each additional bridge

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testValidMarkDown/build.properties
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testValidMarkDown/build.properties
@@ -1,7 +1,0 @@
-output.. = target/classes/
-bin.includes = META-INF/,\
-               .,\
-               OSGI-INF/,\
-               OH-INF/,
-source.. = src/main/java/,\
-           src/main/resources/

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <pde.core.version>3.11.1</pde.core.version>
     <sat.version>0.12.0</sat.version>
     <jdt-annotations.version>2.1.0</jdt-annotations.version>
-    <flexmark.version>0.60.0</flexmark.version>
+    <flexmark.version>0.64.0</flexmark.version>
     <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
     <jetty.server.version>9.4.20.v20190813</jetty.server.version>
     <saxon.version>9.1.0.8</saxon.version>


### PR DESCRIPTION
* Use flexmark 0.64.0
* Stop checking build.properties files which are no longer used
* Fix MarkdownCheck false positives for lists with paragraphs

This fixes the "The line after a Markdown list must be empty." false positives for Markdown lists that use paragraphs such as:

```
* Lorem ipsum dolor sit amet, consectetur adipiscing elit,
  sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
* Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
  nisi ut aliquip ex ea commodo consequat.
```