### PR TITLE
Upgrade SpotBugs to 4.7.0

### DIFF
--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -117,8 +117,8 @@ Parameters:
 | **spotbugsRuleset** | String | Relative path to the XML that specifies the bug detectors which should be run. If not set the default file will be used|
 | **spotbugsInclude** | String | Relative path to the XML that specifies the bug instances that will be included in the report. If not set the default file will be used|
 | **spotbugsExclude** | String | Relative path to the XML that specifies the bug instances that will be excluded from the report. If not set the default file will be used|
-| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.4.2.2**) |
-| **spotbugs.version** | String | The version of SpotBugs that will be used (default value is **4.4.2**) |
+| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.6.0.0**) |
+| **spotbugs.version** | String | The version of SpotBugs that will be used (default value is **4.7.0**) |
 | **spotbugsPlugins** | List<Dependency> | A list with artifacts that contain additional detectors/patterns for SpotBugs |
 | **findbugs.slf4j.version** | String | The version of the findbugs-slf4j plugin that will be used (default value is **1.5.0**)|
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <maven.resources.version>2.4</maven.resources.version>
     <pmd.version>6.39.0</pmd.version>
     <checkstyle.version>8.45.1</checkstyle.version>
-    <spotbugs.version>4.4.2</spotbugs.version>
+    <spotbugs.version>4.7.0</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.6.0</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.6.0</maven.plugin.annotations.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -83,7 +83,7 @@ public class SpotBugsChecker extends AbstractChecker {
     /**
      * The version of the spotbugs-maven-plugin that will be used
      */
-    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.4.2.2")
+    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.6.0.0")
     private String spotbugsMavenPluginVersion;
 
     /**
@@ -95,7 +95,7 @@ public class SpotBugsChecker extends AbstractChecker {
     /**
      * The version of the spotbugs that will be used
      */
-    @Parameter(property = "spotbugs.version", defaultValue = "4.4.2")
+    @Parameter(property = "spotbugs.version", defaultValue = "4.7.0")
     private String spotBugsVersion;
 
     /**


### PR DESCRIPTION
Upgrades Spotbugs from 4.4.2 to 4.7.0.

This fixes SecurityManager deprecation warnings when using Java 17.

For release notes, see:

https://github.com/spotbugs/spotbugs/blob/master/CHANGELOG.md#470---2022-04-14