### PR TITLE
GitHub Actions workflow improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-.java text=auto
-.xml text=auto
+*.java text=auto
+*.xml text=auto

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,23 +19,23 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '11', '17' ]
-        maven: [ '3.8.4']
+        maven: [ '3.8.6' ]
         os: [ 'ubuntu-20.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         if: github.head_ref == ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checkout merge
         if: github.head_ref != ''
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: refs/pull/${{github.event.pull_request.number}}/merge
 
       - name: Set up Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.m2/repository
@@ -45,13 +45,13 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Set up Maven ${{ matrix.maven }}
-        uses: stCarolas/setup-maven@v4.2
+        uses: stCarolas/setup-maven@v4.4
         with:
           maven-version: ${{ matrix.maven }}
 
@@ -67,14 +67,14 @@ jobs:
 
       - name: Upload Build Log
         if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: build-log-java-${{ matrix.java }}-${{ matrix.os }}
           path: build.log
 
       - name: Upload SAT Summary Report
         if: ${{ always() && ((steps.build.outcome == 'success') || (steps.build.outcome == 'failure')) }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: sat-summary-report
           path: target/summary_report.html


### PR DESCRIPTION
* Upgrade actions to latest versions
* Upgrade Maven to 3.8.6
* Use Temurin JDK instead of Zulu JDK

The Temurin JDK is preinstalled in the [Ubuntu image](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#java) whereas the Zulu JDK first need to be downloaded.
It should also perform better because the Temurin JDK is linked to glibc 2.12 whereas the Zulu JDK is linked to glibc 2.5.

Also adds missing wildcards to the .gitattributes file.