### PR TITLE
Upgrade PMD from 6.39.0 to 6.53.0

### DIFF
--- a/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/UseSLF4JLoggerRule.xml
+++ b/custom-checks/pmd/src/test/resources/org/openhab/tools/analysis/pmd/test/xml/UseSLF4JLoggerRule.xml
@@ -2,7 +2,8 @@
 <test-data  xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
-  <test-code reinitializeRule="false" regressionTest="true">
+  <!-- this test was previously marked with reinitializeRule="false", this has not effect anymore since PMD 6.48.0 -->
+  <test-code>
     <description>Java util logger is used</description>
     <expected-problems>1</expected-problems>
     <expected-linenumbers>5</expected-linenumbers>
@@ -16,7 +17,7 @@ class Foo{
 ]]></code>
   </test-code>
 
-  <test-code reinitializeRule="true" regressionTest="true">
+  <test-code>
     <description>Multiple different loggers are used</description>
     <expected-problems>4</expected-problems>
     <expected-linenumbers>3, 5, 6, 8</expected-linenumbers>
@@ -35,7 +36,7 @@ class Foo{
 ]]></code>
   </test-code>
 
-  <test-code reinitializeRule="true" regressionTest="true">
+  <test-code>
     <description>No logger is used</description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[
@@ -44,7 +45,7 @@ class Foo{
 ]]></code>
   </test-code>
 
-  <test-code reinitializeRule="true" regressionTest="true">
+  <test-code>
     <description>Variable named logger that doesn't reference a Logger</description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[
@@ -53,7 +54,7 @@ class Foo{
 }
 ]]></code>
   </test-code>
-    <test-code reinitializeRule="true" regressionTest="true">
+    <test-code>
     <description>Unknown logger used</description>
     <expected-problems>1</expected-problems>
     <expected-linenumbers>2</expected-linenumbers>
@@ -63,7 +64,7 @@ class Foo{
 }
 ]]></code>
   </test-code>
-  <test-code reinitializeRule="true" regressionTest="true">
+  <test-code>
     <description>Real smarthome class</description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[
@@ -191,7 +192,7 @@ public class RawType implements PrimitiveType, State {
 }
 ]]></code>
   </test-code>
-  <test-code reinitializeRule="true" regressionTest="true">
+  <test-code>
     <description>Unresolved inferred var types</description>
     <expected-problems>0</expected-problems>
     <code><![CDATA[

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.0</maven.resources.version>
-    <pmd.version>6.39.0</pmd.version>
+    <pmd.version>6.53.0</pmd.version>
     <checkstyle.version>8.45.1</checkstyle.version>
     <spotbugs.version>4.7.0</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -60,7 +60,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.15.0")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.20.0")
     private String mavenPmdVersion;
 
     /**
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "6.39.0";
+    private static final String PMD_VERSION = "6.53.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */

--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -6,11 +6,11 @@
 	<description>Default set of PMD rules used for checking all bundles</description>
 
 	<rule ref="category/java/errorprone.xml/EmptyIfStmt">
-		<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_errorprone.html for all below -->
+		<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_errorprone.html for all below -->
 		<!-- Priorities range in value from 1 to 5, with 5 being the lowest priority -->
 		<!-- We will use only priority 1,2 and 3 so the results of PMD can be comparable with the results of the other tools -->
 
-		<!-- See https://docs.pmd-code.org/apidocs/pmd-core/6.39.0/net/sourceforge/pmd/RulePriority.html -->
+		<!-- See https://docs.pmd-code.org/apidocs/pmd-core/6.53.0/net/sourceforge/pmd/RulePriority.html -->
 		<priority>3</priority>
 	</rule>
 	<rule ref="category/java/errorprone.xml/EmptyWhileStmt">
@@ -74,7 +74,7 @@
 		<priority>2</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_multithreading.html -->
+	<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_multithreading.html -->
 	<rule ref="category/java/multithreading.xml/DontCallThreadRun">
 		<priority>2</priority>
 	</rule>
@@ -95,7 +95,7 @@
 	</rule>
 
 
-	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_bestpractices.html -->
+	<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_bestpractices.html -->
 	<rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace">
 		<priority>1</priority>
 	</rule>
@@ -103,7 +103,7 @@
 		<priority>2</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_design.html -->
+	<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_design.html -->
 	<rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes">
 		<priority>2</priority>
 	</rule>
@@ -120,7 +120,7 @@
 		<priority>3</priority>
 	</rule>
 
-	<!-- See https://pmd.github.io/pmd-6.39.0/pmd_rules_java_performance.html -->
+	<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_performance.html -->
 	<rule ref="category/java/performance.xml/AvoidArrayLoops">
 		<priority>3</priority>
 	</rule>


### PR DESCRIPTION
Adapt rule file due to deprecation of parameters
reinitializeRule and regressionTest.

For release notes, see:

* https://pmd.github.io/pmd-6.39.0/pmd_release_notes.html
* https://pmd.github.io/pmd-6.39.0/pmd_release_notes_old.html

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>