### PR TITLE
Adjust to core changes (addonSchema)

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -76,7 +76,7 @@
 	<module name="org.openhab.tools.analysis.checkstyle.OhInfXmlValidationCheck">
 		<property name="severity" value="error"/>
 		<property name="thingSchema" value="https://openhab.org/schemas/thing-description-1.0.0.xsd"/>
-		<property name="bindingSchema" value="https://openhab.org/schemas/binding-1.0.0.xsd"/>
+		<property name="addonSchema" value="https://openhab.org/schemas/addon-1.0.0.xsd"/>
 		<property name="configSchema" value="https://openhab.org/schemas/config-description-1.0.0.xsd"/>
 	</module>
 


### PR DESCRIPTION
When I try to use latest custom build on current core (mvn verify), I get the following error:

```[ERROR] Failed to execute goal org.openhab.tools.sat:sat-plugin:0.14.0-SNAPSHOT:checkstyle (sat-all) on project org.openhab.core: An error has occurred in Checkstyle report generation.: Failed during checkstyle configuration: cannot initialize module org.openhab.tools.analysis.checkstyle.OhInfXmlValidationCheck - Property 'bindingSchema' does not exist, please check the documentation -> [Help 1]```

With this change, it runs fine.