### PR TITLE
Prevent warnings when running pmd goal

### DIFF
--- a/sat-plugin/src/main/resources/configuration/pmd.properties
+++ b/sat-plugin/src/main/resources/configuration/pmd.properties
@@ -1,4 +1,3 @@
 pmd.custom.targetDirectory=${project.build.directory}/code-analysis
 pmd.custom.compileSourceRoots=${project.build.directory}/../src/main/java,${project.build.directory}/../src/test/java
 linkXRef=false
-outputEncoding=UTF-8


### PR DESCRIPTION
Fixes the following warnings when building with Maven 3.9.x:

`[WARNING]  Parameter 'outputEncoding' (user property 'outputEncoding') is read-only, must not be used in configuration`