### PR TITLE
Fix compilerArguments deprecation warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,11 +403,11 @@
         <version>${maven.plugin.compiler.version}</version>
         <configuration>
           <compilerId>eclipse</compilerId>
-          <compilerArguments>
-            <annotationpath>CLASSPATH</annotationpath>
-            <classpath>${project.build.directory}/dependency</classpath>
-          </compilerArguments>
           <compilerArgs>
+            <arg>-annotationpath</arg>
+            <arg>CLASSPATH</arg>
+            <arg>-classpath</arg>
+            <arg>${project.build.directory}/dependency</arg>
             <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion</arg>
             <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
           </compilerArgs>


### PR DESCRIPTION
This fixes the following warnings:

```
[WARNING] Parameter 'compilerArguments' is deprecated: use {@link #compilerArgs} instead.
```

Related to openhab/openhab-core#3512