### PR TITLE
Fix unknown additionalparam warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,9 +460,6 @@
             <goals>
               <goal>jar</goal>
             </goals>
-            <configuration>
-              <additionalparam>${javadoc.opts}</additionalparam>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
This fixes the following warning:

```
[WARNING] Parameter 'additionalparam' is unknown for plugin 'maven-javadoc-plugin:3.4.1:jar (attach-javadocs)'
```

It looks like this was never used ever since it was added in 55a2a1b021b1810d5c2aa4619fbe2de1541bc017