### PR TITLE
Upgrade Checkstyle to 10.14.0

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
@@ -24,7 +24,7 @@ import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.FileContents;
 import com.puppycrawl.tools.checkstyle.api.TextBlock;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
-import com.puppycrawl.tools.checkstyle.utils.CheckUtil;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.MissingJavadocMethodCheck;
 import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
 
 /**
@@ -123,8 +123,8 @@ public class JavadocMethodStyleCheck extends AbstractCheck {
 
     @Override
     public void visitToken(DetailAST ast) {
-        boolean skipCheck = (CheckUtil.isSetterMethod(ast) || CheckUtil.isGetterMethod(ast))
-                && allowMissingPropertyJavadoc;
+        boolean skipCheck = (MissingJavadocMethodCheck.isSetterMethod(ast)
+                || MissingJavadocMethodCheck.isGetterMethod(ast)) && allowMissingPropertyJavadoc;
         if (!skipCheck) {
             visit(ast);
         }

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -101,7 +101,7 @@ Parameters:
 | ------ | ------| -------- |
 | **checkstyleRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **checkstyleFilter** | String | Relative path of the suppressions XML file to use. If not set the default filter file will be used |
-| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.1.2**)|
+| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.3.1**)|
 | **checkstylePlugins** | List<Dependency> | A list with artifacts that contain additional checks for Checkstyle |
 | **checkstyleProperties** | String | Relative path of the properties file to use in the ruleset to configure specific checks |
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.0</maven.resources.version>
     <pmd.version>6.53.0</pmd.version>
-    <checkstyle.version>10.6.0</checkstyle.version>
+    <checkstyle.version>10.14.0</checkstyle.version>
     <spotbugs.version>4.8.3</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.8.5</maven.plugin.api.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -53,7 +53,7 @@ public class CheckstyleChecker extends AbstractChecker {
     /**
      * The version of the maven-checkstyle-plugin that will be used
      */
-    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.2.1")
+    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.3.1")
     private String checkstyleMavenVersion;
 
     /**
@@ -118,7 +118,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.6.0"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.14.0"));
         checkstylePlugins.forEach(logDependency());
 
         String baseDir = mavenProject.getBasedir().toString();


### PR DESCRIPTION
Upgrades Checkstyle from 10.6.0 to 10.14.0.

For release notes, see:

https://checkstyle.sourceforge.io/releasenotes.html