### PR TITLE
Fix dark mode scrollbars in Chrome

### DIFF
--- a/sat-plugin/src/main/resources/report/create_html.xslt
+++ b/sat-plugin/src/main/resources/report/create_html.xslt
@@ -56,6 +56,7 @@
 					a {color: #000000;}
 					
 					@media (prefers-color-scheme: dark) {
+						:root {color-scheme:dark;}
 						body {color:#dddddd;background-color:#121212;}
 						table.details tr th a {color:#dddddd;}
 						table.details tr th {background:#0f0f0f;}

--- a/sat-plugin/src/main/resources/report/summary.html
+++ b/sat-plugin/src/main/resources/report/summary.html
@@ -15,6 +15,7 @@
 					a {color: #000000;}
 					
 					@media (prefers-color-scheme: dark) {
+						:root {color-scheme:dark;}
 						body {color:#dddddd;background-color:#121212;}
 						table.details tr th a {color:#dddddd;}
 						table.details tr th {background:#0f0f0f;}


### PR DESCRIPTION
This fixes the issue that when using Chrome the scrolbars are still very bright and not dark.

### Before

![Screenshot from 2024-06-14 22-56-57](https://github.com/openhab/static-code-analysis/assets/12213581/d233b43b-a6ad-414d-a84c-f58696a92a46)

### After

![Screenshot from 2024-06-14 22-58-01](https://github.com/openhab/static-code-analysis/assets/12213581/5a88ef4b-764c-4ba0-9f28-21b8fe1e9e05)
