### PR TITLE
Upgrade PMD to 7.8.0

### DIFF
--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -87,7 +87,7 @@ Parameters:
 | ------ | ------| -------- |
 | **pmdRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **pmdFilter** | String | Relative path of a suppression.properties file that lists classes and rules to be excluded from failures. If not set no classes and no rules will be excluded |
-| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.24.0**)|
+| **maven.pmd.version** | String | The version of the maven-pmd-plugin that will be used (Default value is **3.26.0**)|
 | **pmdPlugins** | List<Dependency> | A list with artifacts that contain additional checks for PMD |
 
 ### sat-plugin:checkstyle

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.0</maven.resources.version>
-    <pmd.version>7.4.0</pmd.version>
+    <pmd.version>7.8.0</pmd.version>
     <checkstyle.version>10.17.0</checkstyle.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -60,7 +60,7 @@ public class PmdChecker extends AbstractChecker {
     /**
      * The version of the maven-pmd-plugin that will be used
      */
-    @Parameter(property = "maven.pmd.version", defaultValue = "3.24.0")
+    @Parameter(property = "maven.pmd.version", defaultValue = "3.26.0")
     private String mavenPmdVersion;
 
     /**
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "7.4.0";
+    private static final String PMD_VERSION = "7.8.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */


### PR DESCRIPTION
Upgrades PMD from 7.4.0 to 7.8.0

For release notes, see:

* https://docs.pmd-code.org/pmd-doc-7.8.0/pmd_release_notes.html
* https://docs.pmd-code.org/pmd-doc-7.8.0/pmd_release_notes_old.html