### PR TITLE
Always run HTTP server on random port in CachingHttpClientTest

### DIFF
--- a/custom-checks/checkstyle/pom.xml
+++ b/custom-checks/checkstyle/pom.xml
@@ -76,4 +76,36 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <configuration>
+              <portNames>
+                <portName>http.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <http.port>${http.port}</http.port>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
@@ -55,7 +55,7 @@ public class CachingHttpClientTest {
 
     private static final String PATH_TO_RESOURCE = "/found";
     private static final String PATH_TO_MISSING_RESOURCE = "/notFound";
-    private static final int TEST_PORT = 9090;
+    private static final int TEST_PORT = Integer.getInteger("http.port", 9090);
     private static final String TEST_HOST = "localhost";
     private static final int TEST_TIMEOUT = 1000;
     private static final String SERVER_RESPONSE = "content";

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,12 @@
         </plugin>
 
         <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+
+        <plugin>
           <groupId>org.openhab.tools.sat</groupId>
           <artifactId>sat-plugin</artifactId>
           <version>${sat.version}</version>


### PR DESCRIPTION
This will prevent the test from failing whenever something else uses port 9090.