### PR TITLE
Start license headers with `/*` instead of `/**`

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorContributionDescriptionCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorTagCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AuthorTagCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AvoidScheduleAtFixedRateCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/AvoidScheduleAtFixedRateCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/DeclarativeServicesDependencyInjectionCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/DeclarativeServicesDependencyInjectionCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ForbiddenPackageUsageCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/InheritDocCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/InheritDocCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/JavadocMethodStyleCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafAddonFeatureCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafFeatureCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/KarafFeatureCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/MissingJavadocFilterCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/MissingJavadocFilterCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NoEmptyLineSeparatorCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/NullAnnotationsCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlLabelCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlLabelCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlUsageCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlValidationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OhInfXmlValidationCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OnlyTabIndentationCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OverridingParentPomConfigurationCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/ParameterizedRegexpHeaderCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/PomXmlCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequiredFilesCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/RequiredFilesCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractOhInfXmlCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractOhInfXmlCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/AbstractStaticCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/CheckConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/NoResultException.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/api/NoResultException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownVisitorCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/CachingHttpClient.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/CachingHttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/ContentReceivedCallback.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/ContentReceivedCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/SatCheckUtils.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/utils/SatCheckUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorContributionDescriptionCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AvoidScheduleAtFixedRateCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/DeclarativeServicesDependencyInjectionCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ForbiddenPackageUsageCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/InheritDocCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/JavadocMethodStyleCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafAddonFeatureCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/KarafFeatureCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/LoggedMessagesExtension.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/LoggedMessagesExtension.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MissingJavadocFilterCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NoEmptyLineSeparatorCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/NullAnnotationsCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlLabelCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlUsageCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OhInfXmlValidationCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OnlyTabIndentationCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OverridingParentPomConfigurationCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/ParameterizedRegexpHeaderCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/PomXmlCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/RequiredFilesCheckTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/utils/CachingHttpClientTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
+++ b/custom-checks/pmd/src/main/java/org/openhab/tools/analysis/pmd/UseSLF4JLoggerRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/ClasspathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/CustomRulesTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/CustomRulesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
+++ b/custom-checks/pmd/src/test/java/org/openhab/tools/analysis/pmd/test/PomTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,6 @@
             <strictCheck>true</strictCheck>
             <aggregate>true</aggregate>
             <mapping>
-              <java>JAVADOC_STYLE</java>
               <xml>xml-header-style</xml>
             </mapping>
             <useDefaultExcludes>true</useDefaultExcludes>

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportExecutionListener.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportExecutionListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportHtmlGenerator.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportHtmlGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportLifecycleParticipant.java
+++ b/sat-extension/src/main/java/org/openhab/tools/analysis/report/SummaryReportLifecycleParticipant.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtil.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/ReportUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/report/SummaryHtmlGeneration.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/report/SummaryHtmlGeneration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/AbstractChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/internal/SpotBugsVisitors.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/internal/SpotBugsVisitors.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/sat-plugin/src/test/java/org/openhab/tools/analysis/report/ReportMojoTest.java
+++ b/sat-plugin/src/test/java/org/openhab/tools/analysis/report/ReportMojoTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) 2010-2025 Contributors to the openHAB project
  *
  * See the NOTICE file(s) distributed with this work for additional

--- a/tools/static-code-analysis/checkstyle/ruleset.properties
+++ b/tools/static-code-analysis/checkstyle/ruleset.properties
@@ -1,6 +1,6 @@
 checkstyle.forbiddenPackageUsageCheck.forbiddenPackages=com.google.common,gnu.io,javax.comm,org.apache.commons,org.joda.time,org.junit.Assert,org.junit.Test,si.uom,tech.units
 checkstyle.forbiddenPackageUsageCheck.exceptions=
-checkstyle.headerCheck.content=^/\\*\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
+checkstyle.headerCheck.content=^/\\*$\\n^ \\* Copyright \\(c\\) {0}-{1} Contributors to the openHAB project$\\n^ \\*$\\n^ \\* See the NOTICE file\\(s\\) distributed with this work for additional$\\n^ \\* information.$\\n^ \\*$\\n^ \\* This program and the accompanying materials are made available under the$\\n^ \\* terms of the Eclipse Public License 2\\.0 which is available at$\\n^ \\* http://www.eclipse.org/legal/epl\\-2\\.0$\\n^ \\*$\\n^ \\* SPDX-License-Identifier: EPL-2.0$
 checkstyle.headerCheck.values=2010,2025
 checkstyle.requiredFilesCheck.extensions=xml,md
 checkstyle.requiredFilesCheck.files=pom.xml


### PR DESCRIPTION
Prevents JavaDoc tooling issues because these tools check comments starting with `/**`.

Depends on #476