### PR TITLE
Upgrade dependencies, SpotBugs, PMD, CheckStyle

### DIFF
--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/AuthorTagCheckTest.java
@@ -65,9 +65,10 @@ public class AuthorTagCheckTest extends AbstractStaticCheckTest {
          * an error is expected at the line where the outer class is declared
          * in the file
          */
-        int warningLine = 1;
+        // since https://github.com/checkstyle/checkstyle/issues/11584 there is no warning
+        // if no javadoc is present
         boolean checkInnerClasses = false;
-        checkFileForAuthorTags(checkInnerClasses, fileName, warningLine);
+        checkFileForAuthorTags(checkInnerClasses, fileName);
     }
 
     @Test
@@ -77,10 +78,10 @@ public class AuthorTagCheckTest extends AbstractStaticCheckTest {
          * errors are expected at the lines where the classes are declared in
          * the file
          */
-        int firstWarningLine = 1;
-        int secondWarningLine = 3;
+        // since https://github.com/checkstyle/checkstyle/issues/11584 there is no warning
+        // if no javadoc is present
         boolean checkInnerClasses = true;
-        checkFileForAuthorTags(checkInnerClasses, fileName, firstWarningLine, secondWarningLine);
+        checkFileForAuthorTags(checkInnerClasses, fileName);
     }
 
     @Test

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -117,7 +117,7 @@ Parameters:
 | **spotbugsRuleset** | String | Relative path to the XML that specifies the bug detectors which should be run. If not set the default file will be used|
 | **spotbugsInclude** | String | Relative path to the XML that specifies the bug instances that will be included in the report. If not set the default file will be used|
 | **spotbugsExclude** | String | Relative path to the XML that specifies the bug instances that will be excluded from the report. If not set the default file will be used|
-| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.8.6.2**) |
+| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.8.6.6**) |
 | **spotbugs.version** | String | The version of SpotBugs that will be used (default value is **4.8.6**) |
 | **spotbugsPlugins** | List<Dependency> | A list with artifacts that contain additional detectors/patterns for SpotBugs |
 | **findbugs.slf4j.version** | String | The version of the findbugs-slf4j plugin that will be used (default value is **1.5.0**)|

--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -101,7 +101,7 @@ Parameters:
 | ------ | ------| -------- |
 | **checkstyleRuleset** | String | Relative path of the XML configuration to use. If not set the default ruleset file will be used |
 | **checkstyleFilter** | String | Relative path of the suppressions XML file to use. If not set the default filter file will be used |
-| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.4.0**)|
+| **maven.checkstyle.version** | String | The version of the maven-checkstyle-plugin that will be used (default value is **3.6.0**)|
 | **checkstylePlugins** | List<Dependency> | A list with artifacts that contain additional checks for Checkstyle |
 | **checkstyleProperties** | String | Relative path of the properties file to use in the ruleset to configure specific checks |
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,24 +61,24 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
     <maven.eclipse.version>2.10</maven.eclipse.version>
-    <junit.version>5.9.1</junit.version>
-    <commons.io.version>2.11.0</commons.io.version>
-    <commons.lang3.version>3.12.0</commons.lang3.version>
+    <junit.version>5.11.4</junit.version>
+    <commons.io.version>2.18.0</commons.io.version>
+    <commons.lang3.version>3.17.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
     <pmd.version>7.9.0</pmd.version>
     <checkstyle.version>10.21.1</checkstyle.version>
     <spotbugs.version>4.8.6</spotbugs.version>
-    <maven.core.version>3.6.0</maven.core.version>
-    <maven.plugin.api.version>3.8.5</maven.plugin.api.version>
-    <maven.plugin.annotations.version>3.7.0</maven.plugin.annotations.version>
+    <maven.core.version>3.9.9</maven.core.version>
+    <maven.plugin.api.version>3.9.9</maven.plugin.api.version>
+    <maven.plugin.annotations.version>3.15.1</maven.plugin.annotations.version>
     <maven.plugin.plugin.version>3.8.2</maven.plugin.plugin.version>
     <maven.plugin.compiler.version>3.13.0</maven.plugin.compiler.version>
-    <mojo.executor.version>2.4.0</mojo.executor.version>
-    <org.jsoup.version>1.7.1</org.jsoup.version>
+    <mojo.executor.version>2.4.1</mojo.executor.version>
+    <org.jsoup.version>1.18.3</org.jsoup.version>
     <sat.version>0.17.0</sat.version>
-    <jdt-annotations.version>2.1.0</jdt-annotations.version>
-    <flexmark.version>0.64.0</flexmark.version>
+    <jdt-annotations.version>2.3.100</jdt-annotations.version>
+    <flexmark.version>0.64.8</flexmark.version>
     <maven.surefire.plugin.version>3.5.2</maven.surefire.plugin.version>
     <jetty.server.version>9.4.50.v20221201</jetty.server.version>
     <saxon.version>9.1.0.8</saxon.version>
@@ -87,7 +87,7 @@
     <spotless.eclipse.version>4.25</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.9</logback.version>
+    <logback.version>1.2.13</logback.version>
     <eea.version>2.4.0</eea.version>
     <m2e.jdt.annotationpath>target/dependency</m2e.jdt.annotationpath>
   </properties>
@@ -130,7 +130,7 @@
       <!-- Required for Checkstyle tests -->
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.1.3</version>
+      <version>1.4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -429,12 +429,14 @@
           <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-eclipse</artifactId>
+            <!-- cannot go beyond 2.12.1 as long as Java11 is in use -->
             <version>2.12.1</version>
           </dependency>
           <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>ecj</artifactId>
-            <version>3.30.0</version>
+            <!-- cannot go beyond 3.33.0 as long as Java11 is in use -->
+            <version>3.33.0</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
     <pmd.version>7.9.0</pmd.version>
-    <checkstyle.version>10.17.0</checkstyle.version>
+    <checkstyle.version>10.21.1</checkstyle.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>
     <maven.plugin.api.version>3.8.5</maven.plugin.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons.lang3.version>3.12.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
-    <pmd.version>7.8.0</pmd.version>
+    <pmd.version>7.9.0</pmd.version>
     <checkstyle.version>10.17.0</checkstyle.version>
     <spotbugs.version>4.8.6</spotbugs.version>
     <maven.core.version>3.6.0</maven.core.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -53,7 +53,7 @@ public class CheckstyleChecker extends AbstractChecker {
     /**
      * The version of the maven-checkstyle-plugin that will be used
      */
-    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.4.0")
+    @Parameter(property = "maven.checkstyle.version", defaultValue = "3.6.0")
     private String checkstyleMavenVersion;
 
     /**
@@ -118,7 +118,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.17.0"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.21.1"));
         checkstylePlugins.forEach(logDependency());
 
         String baseDir = mavenProject.getBasedir().toString();

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "7.8.0";
+    private static final String PMD_VERSION = "7.9.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -83,7 +83,7 @@ public class SpotBugsChecker extends AbstractChecker {
     /**
      * The version of the spotbugs-maven-plugin that will be used
      */
-    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.8.6.2")
+    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.8.6.6")
     private String spotbugsMavenPluginVersion;
 
     /**


### PR DESCRIPTION
I have put all upgrades in one PR - as separate commits - to ease comparing the results before / after.
Pls. ***DO NOT SQUASH***.

*    Upgrades Checkstyle from 10.17.0 to 10.21.1.

    For release notes, see:
    https://github.com/checkstyle/checkstyle/releases

    Note that default behavior for checking tags in javadoc changed
    in version 10.20.2, it will not longer issue a warning about
    missing tags if there is no javadoc section at all.
    See https://github.com/checkstyle/checkstyle/issues/11584

*    Upgrades PMD from 7.8.0 to 7.9.0

    For release notes, see:
    https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.9.0

*    Upgrades spotbugs-maven-plugin from 4.8.6.2 to 4.8.6.6.

    For release notes, see:
    https://github.com/spotbugs/spotbugs-maven-plugin/releases

*    Upgrade dependencies and plugins

    * junit to 5.11.4
    * commons-io to 2.18.0
    * commons-lang3 to 3.17.0
    * maven-plugin-api to 3.9.9
    * maven-plugin-annotations 3.15.1
    * mojo-executor to 2.4.1
    * jsoup to 1.18.3
    * jdt-annotations to 2.3.100
    * flexmark to 0.64.8
    * logback to 1.2.13
    * plexus-compiler-eclipse to 2.15.0
    * ecj to 3.39.0
    * truth to 1.4.4
 

---

Notes:
* spotbugs/spotbugs#1894 is still there in 4.9.0, and seen in our add-ons build in js automation.
* spotbugs 4.9.0 runs into OOM in googlestt binding, that's why I stick to 4.8.6. spotbugs-maven-plugin is anyway not yet available as 4.9.x.y release
* We still stick to Java 11, see discussion [here](https://github.com/openhab/static-code-analysis/pull/451). This starts blocking dependency upgrades and should be resolved.
