### PR TITLE
Remove PMD rule SimplifyBooleanReturns

### DIFF
--- a/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/pmd/rules.xml
@@ -102,9 +102,6 @@
 	<rule ref="category/java/design.xml/SimplifyBooleanExpressions">
 		<priority>3</priority>
 	</rule>
-	<rule ref="category/java/design.xml/SimplifyBooleanReturns">
-		<priority>3</priority>
-	</rule>
 
 	<!-- See https://pmd.github.io/pmd-6.53.0/pmd_rules_java_performance.html -->
 	<rule ref="category/java/performance.xml/AvoidArrayLoops">


### PR DESCRIPTION
Remove [SimplifyBooleanReturns](https://docs.pmd-code.org/pmd-doc-7.8.0/pmd_rules_java_design.html#simplifybooleanreturns) from default rule set.
Readability of code tends to be better if this rule is not enforced.

It can be re-activated on project basis by using a custom ruleset, see configuration parameter pmdRuleset and supply an adapted rule set similar to rules.xml from this repo.

This is basically my conclusion from openhab/openhab-core#4555 and #4567.
See the code changes proposed in #4555 to get an impression of the readability of code compliant to this rule.