### PR TITLE
Upgrade PMD to 7.14.0 and Checkstyle to 10.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons.lang3.version>3.17.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
-    <pmd.version>7.13.0</pmd.version>
+    <pmd.version>7.14.0</pmd.version>
     <checkstyle.version>10.23.0</checkstyle.version>
     <spotbugs.version>4.9.3</spotbugs.version>
     <maven.core.version>3.9.9</maven.core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
     <pmd.version>7.14.0</pmd.version>
-    <checkstyle.version>10.23.0</checkstyle.version>
+    <checkstyle.version>10.25.0</checkstyle.version>
     <spotbugs.version>4.9.3</spotbugs.version>
     <maven.core.version>3.9.9</maven.core.version>
     <maven.plugin.api.version>3.9.9</maven.plugin.api.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -118,7 +118,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.23.0"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.25.0"));
         checkstylePlugins.forEach(logDependency());
 
         String baseDir = mavenProject.getBasedir().toString();

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/PmdChecker.java
@@ -69,7 +69,7 @@ public class PmdChecker extends AbstractChecker {
     @Parameter
     private List<Dependency> pmdPlugins = new ArrayList<>();
 
-    private static final String PMD_VERSION = "7.13.0";
+    private static final String PMD_VERSION = "7.14.0";
     /**
      * Location of the properties files that contains configuration options for the maven-pmd-plugin
      */


### PR DESCRIPTION
Separate PRs, do not squash!

* Upgrades Checkstyle from 10.23.0 to 10.25.0.

    For release notes, see:
    https://github.com/checkstyle/checkstyle/releases

* Upgrades PMD from 7.13.0 to 7.14.0.
    Now defaults to parallel execution.

    For release notes, see:
    https://github.com/pmd/pmd/releases/tag/pmd_releases%2F7.14.0


Comparison of output before/after the patch will be made available once my build finishes.