### PR TITLE
Upgrade commons-io to 2.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
     <maven.eclipse.version>2.10</maven.eclipse.version>
     <junit.version>5.11.4</junit.version>
-    <commons.io.version>2.18.0</commons.io.version>
+    <commons.io.version>2.20.0</commons.io.version>
     <commons.lang3.version>3.17.0</commons.lang3.version>
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>


### PR DESCRIPTION
Upgrade commons-io from 2.18.0 to 2.20.0.

Changelogs:
https://commons.apache.org/proper/commons-io/changes.html#a2.19.0

https://commons.apache.org/proper/commons-io/changes.html#a2.20.0