### PR TITLE
Add check for Optional used as a field type

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OptionalFieldCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/OptionalFieldCheck.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.tools.analysis.checkstyle;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+/**
+ * Check that generates <b> WARNING </b> when {@link java.util.Optional} is used as a field type.
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class OptionalFieldCheck extends AbstractCheck {
+
+    private static final String WARNING_MESSAGE_OPTIONAL_FIELD_USAGE = "Avoid using Optional as a field type";
+
+    private boolean importedOptional = false;
+    private boolean starImportJavaUtil = false;
+
+    @Override
+    public int[] getDefaultTokens() {
+        return getAcceptableTokens();
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        return new int[] { TokenTypes.IMPORT, TokenTypes.VARIABLE_DEF };
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        return CommonUtil.EMPTY_INT_ARRAY;
+    }
+
+    @Override
+    public void beginTree(DetailAST rootAST) {
+        importedOptional = false;
+        starImportJavaUtil = false;
+    }
+
+    @Override
+    public void visitToken(DetailAST ast) {
+        switch (ast.getType()) {
+            case TokenTypes.IMPORT:
+                handleImport(ast);
+                break;
+            case TokenTypes.VARIABLE_DEF:
+                handleVariableDef(ast);
+                break;
+            default:
+                // No action
+        }
+    }
+
+    private void handleImport(DetailAST ast) {
+        DetailAST dot = ast.findFirstToken(TokenTypes.DOT);
+        if (dot == null) {
+            return;
+        }
+
+        String importText = flattenName(dot);
+        if ("java.util.Optional".equals(importText)) {
+            importedOptional = true;
+        } else if ("java.util.*".equals(importText)) {
+            starImportJavaUtil = true;
+        }
+    }
+
+    private void handleVariableDef(DetailAST ast) {
+        // Ensure this is a field (not a local variable in a method)
+        if (!isField(ast)) {
+            return;
+        }
+
+        DetailAST typeAst = ast.findFirstToken(TokenTypes.TYPE);
+        if (typeAst == null) {
+            return;
+        }
+
+        DetailAST firstChild = typeAst.getFirstChild();
+        if (firstChild == null) {
+            return;
+        }
+
+        String typeName = flattenName(firstChild);
+
+        // Fully qualified
+        if ("java.util.Optional".equals(typeName)) {
+            log(ast, WARNING_MESSAGE_OPTIONAL_FIELD_USAGE);
+            return;
+        }
+
+        // Simple name with import
+        if ("Optional".equals(typeName) && (importedOptional || starImportJavaUtil)) {
+            log(ast, WARNING_MESSAGE_OPTIONAL_FIELD_USAGE);
+        }
+    }
+
+    private boolean isField(DetailAST variableDefAst) {
+        DetailAST parent = variableDefAst.getParent();
+        return parent != null && parent.getType() == TokenTypes.OBJBLOCK && parent.getParent() != null
+                && parent.getParent().getType() == TokenTypes.CLASS_DEF;
+    }
+
+    /**
+     * Flatten a DOT/IDENT/STAR subtree into a dotted name, collecting only identifier parts and '*'.
+     *
+     * Examples:
+     * - IDENT -> "Optional"
+     * - DOT(java, util, Optional, TYPE_ARGUMENTS) -> "java.util.Optional"
+     * - DOT(java, util, STAR) -> "java.util.*"
+     * 
+     * Example tree for fully qualified:
+     *
+     * <pre>
+     * --DOT -> .
+     *    |--DOT -> .
+     *        |--IDENT -> java
+     *        |--IDENT -> util
+     *    |--IDENT -> Optional
+     *    |--ARGUMENTS
+     * </pre>
+     */
+    private String flattenName(DetailAST node) {
+        List<String> parts = new ArrayList<>();
+        collectNameParts(node, parts);
+        if (parts.isEmpty()) {
+            return "";
+        }
+        return String.join(".", parts);
+    }
+
+    private void collectNameParts(DetailAST node, List<String> parts) {
+        if (node == null) {
+            return;
+        }
+
+        final int type = node.getType();
+
+        if (type == TokenTypes.IDENT) {
+            parts.add(node.getText());
+            return;
+        }
+
+        if (type == TokenTypes.STAR) {
+            // Wildcard import
+            parts.add("*");
+            return;
+        }
+
+        if (type == TokenTypes.DOT) {
+            // Iterate children in order and collect IDENT / DOT / STAR, ignore TYPE_ARGUMENTS, etc.
+            DetailAST child = node.getFirstChild();
+            while (child != null) {
+                final int childType = child.getType();
+                if (childType == TokenTypes.IDENT) {
+                    parts.add(child.getText());
+                } else if (childType == TokenTypes.DOT) {
+                    // Recurse to expand nested package parts
+                    collectNameParts(child, parts);
+                } else if (childType == TokenTypes.STAR) {
+                    parts.add("*");
+                } // Else ignore TYPE_ARGUMENTS, TYPE_PARAMETERS, etc.
+                child = child.getNextSibling();
+            }
+        }
+    }
+}

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OptionalFieldCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/OptionalFieldCheckTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.tools.analysis.checkstyle.test;
+
+import org.junit.jupiter.api.Test;
+import org.openhab.tools.analysis.checkstyle.OptionalFieldCheck;
+import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheckTest;
+
+import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+
+/**
+ * Tests for {@link OptionalFieldCheck}
+ *
+ * @author Jacob Laursen - Initial contribution
+ */
+public class OptionalFieldCheckTest extends AbstractStaticCheckTest {
+
+    @Override
+    protected String getPackageLocation() {
+        return "checkstyle/optionalFieldCheckTest";
+    }
+
+    @Test
+    public void testOptionalFieldFromImportDetected() throws Exception {
+        final String[] expected = { "4:5: Avoid using Optional as a field type" };
+        verify(createModuleConfig(OptionalFieldCheck.class), getPath("OptionalFieldFromImport.java"), expected);
+    }
+
+    @Test
+    public void testOptionalFieldFromStarImportDetected() throws Exception {
+        final String[] expected = { "4:5: Avoid using Optional as a field type" };
+        verify(createModuleConfig(OptionalFieldCheck.class), getPath("OptionalFieldFromStarImport.java"), expected);
+    }
+
+    @Test
+    public void testOptionalFieldFullyQualifiedDetected() throws Exception {
+        final String[] expected = { "2:5: Avoid using Optional as a field type" };
+        verify(createModuleConfig(OptionalFieldCheck.class), getPath("OptionalFieldFullyQualified.java"), expected);
+    }
+
+    @Test
+    public void testOptionalFieldFromImportOtherPackageNotDetected() throws Exception {
+        verify(createModuleConfig(OptionalFieldCheck.class), getPath("OptionalFieldFromImportOtherPackage.java"),
+                CommonUtil.EMPTY_STRING_ARRAY);
+    }
+
+    @Test
+    public void testOptionalLocalVariableNotDetected() throws Exception {
+        verify(createModuleConfig(OptionalFieldCheck.class), getPath("OptionalLocalVariable.java"),
+                CommonUtil.EMPTY_STRING_ARRAY);
+    }
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromImport.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromImport.java
@@ -1,0 +1,5 @@
+import java.util.Optional;
+
+public class OptionalFieldFromImport {
+    private Optional<String> stringOrNoString;
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromImportOtherPackage.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromImportOtherPackage.java
@@ -1,0 +1,5 @@
+import org.openhab.Optional;
+
+public class OptionalFieldFromImportOtherPackage {
+    private Optional<String> stringOrNoString;
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromStarImport.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFromStarImport.java
@@ -1,0 +1,5 @@
+import java.util.*;
+
+public class OptionalFieldFromImport {
+    private Optional<String> stringOrNoString;
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFullyQualified.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalFieldFullyQualified.java
@@ -1,0 +1,3 @@
+public class OptionalFieldFullyQualified {
+    private java.util.Optional<String> stringOrNoString;
+}

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalLocalVariable.java
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/optionalFieldCheckTest/OptionalLocalVariable.java
@@ -1,0 +1,7 @@
+import java.util.Optional;
+
+public class OptionalLocalVariable {
+    private void test() {
+        Optional<String> stringOrNoString;
+    }
+}

--- a/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
+++ b/sat-plugin/src/main/resources/rulesets/checkstyle/rules.xml
@@ -143,6 +143,9 @@
 			<property name="forbiddenPackages" value="${checkstyle.forbiddenPackageUsageCheck.forbiddenPackages}"/>
 			<property name="exceptions" value="${checkstyle.forbiddenPackageUsageCheck.exceptions}"/>
 		</module>
+		<module name="org.openhab.tools.analysis.checkstyle.OptionalFieldCheck">
+			<property name="severity" value="warning"/>
+		</module>
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true"/>
 			<property name="severity" value="info"/>


### PR DESCRIPTION
This adds a check to generate a warning when `Optional` is used as a field type.

`Optional` is primarily meant as a return type, not a field type. See for example Brian Goetz, Java’s language architect, [shedding light](https://stackoverflow.com/questions/26327957/should-java-8-getters-return-optional-type/26328555#26328555) on Oracle’s intention with the `Optional` type.

Example code which did not generate any warnings, but hides a potential `NullPointerException` in a concurrency scenario:

```java
private Optional<String> foo = Optional.empty();

private void test()
{
    if (foo.isPresent()) {
        String bar = foo.get();
    }
}
```

Whereas this will generate a warning:

```java
private @Nullable String foo;

private void test()
{
    if (foo != null) {
        String bar = foo;
    }
}
```

and this will not:

```java
private @Nullable String foo;

private void test()
{
    String foo = this.foo;
    if (foo != null) {
        String bar = foo;
    }
}
```

This is a follow-up to the suggestion made here: https://github.com/openhab/openhab-addons/pull/19061#issuecomment-3128266716

A few @openhab/add-ons-maintainers already favors the idea, but it would be good to hear from @openhab/core-maintainers as well in case anyone thinks this approach is too drastic or are directly against it.

It should be mentioned that some add-ons already use `Optional` as a field type and thus will start having these warnings. I intend to create at least a few pull requests to address some of those.