### PR TITLE
Upgrade SpotBugs to 4.9.4

### DIFF
--- a/docs/maven-plugin.md
+++ b/docs/maven-plugin.md
@@ -117,8 +117,8 @@ Parameters:
 | **spotbugsRuleset** | String | Relative path to the XML that specifies the bug detectors which should be run. If not set the default file will be used|
 | **spotbugsInclude** | String | Relative path to the XML that specifies the bug instances that will be included in the report. If not set the default file will be used|
 | **spotbugsExclude** | String | Relative path to the XML that specifies the bug instances that will be excluded from the report. If not set the default file will be used|
-| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.9.3.0**) |
-| **spotbugs.version** | String | The version of SpotBugs that will be used (default value is **4.9.3**) |
+| **maven.spotbugs.version** | String | The version of the spotbugs-maven-plugin that will be used (default value is **4.9.4.0**) |
+| **spotbugs.version** | String | The version of SpotBugs that will be used (default value is **4.9.4**) |
 | **spotbugsPlugins** | List<Dependency> | A list with artifacts that contain additional detectors/patterns for SpotBugs |
 | **findbugs.slf4j.version** | String | The version of the findbugs-slf4j plugin that will be used (default value is **1.5.0**)|
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <maven.resources.version>3.3.1</maven.resources.version>
     <pmd.version>7.16.0</pmd.version>
     <checkstyle.version>10.26.1</checkstyle.version>
-    <spotbugs.version>4.9.3</spotbugs.version>
+    <spotbugs.version>4.9.4</spotbugs.version>
     <maven.core.version>3.9.9</maven.core.version>
     <maven.plugin.api.version>3.9.9</maven.plugin.api.version>
     <maven.plugin.annotations.version>3.15.1</maven.plugin.annotations.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/SpotBugsChecker.java
@@ -83,7 +83,7 @@ public class SpotBugsChecker extends AbstractChecker {
     /**
      * The version of the spotbugs-maven-plugin that will be used
      */
-    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.9.3.0")
+    @Parameter(property = "maven.spotbugs.version", defaultValue = "4.9.4.0")
     private String spotbugsMavenPluginVersion;
 
     /**
@@ -95,7 +95,7 @@ public class SpotBugsChecker extends AbstractChecker {
     /**
      * The version of the spotbugs that will be used
      */
-    @Parameter(property = "spotbugs.version", defaultValue = "4.9.3")
+    @Parameter(property = "spotbugs.version", defaultValue = "4.9.4")
     private String spotBugsVersion;
 
     /**


### PR DESCRIPTION
Upgrades SpotBugs from 4.9.3 to 4.9.4.
For release notes, see:
https://github.com/spotbugs/spotbugs/blob/master/CHANGELOG.md#494---2025-08-07

Upgrades spotbugs-maven-plugin from 4.9.3.0 to 4.9.4.0. For release notes, see:
https://github.com/spotbugs/spotbugs-maven-plugin/releases