### PR TITLE
Upgrade checkstyle to 11.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <mockito.version>4.10.0</mockito.version>
     <maven.resources.version>3.3.1</maven.resources.version>
     <pmd.version>7.16.0</pmd.version>
-    <checkstyle.version>10.26.1</checkstyle.version>
+    <checkstyle.version>11.0.0</checkstyle.version>
     <spotbugs.version>4.9.3</spotbugs.version>
     <maven.core.version>3.9.9</maven.core.version>
     <maven.plugin.api.version>3.9.9</maven.plugin.api.version>

--- a/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
+++ b/sat-plugin/src/main/java/org/openhab/tools/analysis/tools/CheckstyleChecker.java
@@ -118,7 +118,7 @@ public class CheckstyleChecker extends AbstractChecker {
 
         checkstylePlugins.add(dependency("org.openhab.tools.sat.custom-checks", "checkstyle", plugin.getVersion()));
         // Maven may load an older version, if no version is specified
-        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "10.26.1"));
+        checkstylePlugins.add(dependency("com.puppycrawl.tools", "checkstyle", "11.0.0"));
         checkstylePlugins.forEach(logDependency());
 
         String baseDir = mavenProject.getBasedir().toString();


### PR DESCRIPTION
Upgrade checkstyle from 10.26.1 to 11.0.0

Changlog:
https://github.com/checkstyle/checkstyle/releases/


@wborn, @kaikreuzer 
Checkstyle 11 requires Java 17.
How do we proceed?

I cannot remember right now why we still require Java 11 here. Can you pls. give me a hind?