### PR TITLE
Dependabot for plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,13 @@ updates:
     labels:
       - dependencies
 
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+    allow:
+      - dependency-name: "org.apache.maven.plugins:*"
+      - dependency-name: "org.codehaus.mojo:*"
+      - dependency-name: "*plugin*"
+      - dependency-name: "org.eclipse.jdt:ecj" # eclipse compiler


### PR DESCRIPTION
This will enable dependabot to upgrade plugins.
When merged, this will create a list of PRs:
<img width="750" height="761" alt="grafik" src="https://github.com/user-attachments/assets/f7f721c8-8db8-4d8f-bbb7-aeb2382b048f" />

A few plugins are no longer compatible with Java 11, so the PR will fail.