### PR TITLE
Ignore frontmatter in MarkdownCheck

### DIFF
--- a/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
+++ b/custom-checks/checkstyle/src/main/java/org/openhab/tools/analysis/checkstyle/readme/MarkdownCheck.java
@@ -15,11 +15,13 @@ package org.openhab.tools.analysis.checkstyle.readme;
 import static org.openhab.tools.analysis.checkstyle.api.CheckConstants.*;
 
 import java.io.File;
+import java.util.List;
 
 import org.openhab.tools.analysis.checkstyle.api.AbstractStaticCheck;
 
 import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
 import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.data.MutableDataSet;
@@ -54,6 +56,7 @@ public class MarkdownCheck extends AbstractStaticCheck {
         MutableDataSet options = new MutableDataSet();
         // By setting this option to true, the parser provides line numbers in the original markdown text for each node
         options.set(Parser.TRACK_DOCUMENT_LINES, true);
+        options.set(Parser.EXTENSIONS, List.of(YamlFrontMatterExtension.create()));
 
         Node readmeMarkdownNode = parseMarkdown(fileText, options);
         // CallBack is used in order to use the protected log method of the AbstractStaticCheck in the Visitor

--- a/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
+++ b/custom-checks/checkstyle/src/test/java/org/openhab/tools/analysis/checkstyle/test/MarkdownCheckTest.java
@@ -249,6 +249,11 @@ public class MarkdownCheckTest extends AbstractStaticCheckTest {
         verifyMarkDownFile("testDocFolderWrong", expectedMessages);
     }
 
+    @Test
+    public void testFrontMatterIgnored() throws Exception {
+        verifyMarkDownFile("testFrontMatterIgnored", noMessagesExpected());
+    }
+
     private void createValidConfig() {
         config = createModuleConfig(MarkdownCheck.class);
     }

--- a/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testFrontMatterIgnored/README.md
+++ b/custom-checks/checkstyle/src/test/resources/checkstyle/markdownCheckTest/testFrontMatterIgnored/README.md
@@ -1,0 +1,16 @@
+---
+title: Sample document
+description: |
+  # not a header
+  * not a list
+  ```
+  not code formatting
+  ```
+children:
+  - ["doc/test1", "Test1"]
+  - ["doc/test2", "Test2"]
+---
+
+# Actual Header
+
+Body text.


### PR DESCRIPTION
Add YamlFrontMatterExtension to support frontmatter in the addon readmes: https://github.com/openhab/openhab-website/pull/565

